### PR TITLE
Factor out authentication from upload_sbom

### DIFF
--- a/pia/main.py
+++ b/pia/main.py
@@ -5,13 +5,14 @@ from contextlib import asynccontextmanager
 from typing import Annotated, NoReturn
 
 import jwt
-from fastapi import FastAPI, Header, HTTPException, Request, Response, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, Response, status
 
 from . import __version__, dependencytrack, oidc
 from .config import Settings
 from .models import (
     DependencyTrackUploadPayload,
     PiaUploadPayload,
+    Project,
     Projects,
 )
 
@@ -54,27 +55,20 @@ def _401(msg: str) -> NoReturn:
     )
 
 
-@app.get("/livez")
-async def livez():
-    """Kubernetes liveness probe."""
-    return {"status": "ok"}
+def get_projects(request: Request) -> Projects:
+    """Dependency providing the loaded Projects from app state."""
+    return request.app.state.projects
 
 
-@app.post("/v1/upload/sbom", status_code=status.HTTP_200_OK)
-async def upload_sbom(
-    payload: PiaUploadPayload,
-    request: Request,
+async def authenticate(
     authorization: Annotated[str, Header()],
-):
-    """Handle SBOM upload with OIDC authentication.
+    projects: Annotated[Projects, Depends(get_projects)],
+) -> Project:
+    """Authenticate request via OIDC Bearer token.
 
     Implements authentication flow from DESIGN.md section 3.1.1.
     Token must be provided as Bearer token in Authorization header (RFC6750).
     """
-    # ==========================================================================
-    # Handle Auth Header
-    projects: Projects = request.app.state.projects
-
     logger.info("Received SBOM upload request")
 
     # Extract Bearer token from Authorization header
@@ -139,9 +133,21 @@ async def upload_sbom(
         f"with issuer {verified_claims['iss']}"
     )
 
-    # ==========================================================================
-    # Handle Payload
+    return project
 
+
+@app.get("/livez")
+async def livez():
+    """Kubernetes liveness probe."""
+    return {"status": "ok"}
+
+
+@app.post("/v1/upload/sbom", status_code=status.HTTP_200_OK)
+async def upload_sbom(
+    payload: PiaUploadPayload,
+    project: Annotated[Project, Depends(authenticate)],
+):
+    """Handle SBOM upload."""
     logger.info(
         f"Preparing DependencyTrack payload for {payload.product_name} "
         f"{payload.product_version}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 import pytest
 import yaml
 
+from pia.models import Projects
+
 
 @pytest.fixture
 def test_projects():
@@ -27,3 +29,9 @@ def test_projects_file(tmp_path, test_projects):
     with open(projects_path, "w") as f:
         yaml.dump(test_projects, f)
     return projects_path
+
+
+@pytest.fixture
+def projects(test_projects):
+    """Projects instance built from test_projects, for direct calls."""
+    return Projects(test_projects)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from pia.dependencytrack import DependencyTrackError
+from pia.models import Project
 from pia.oidc import TokenVerificationError
 
 
@@ -45,6 +46,23 @@ def valid_request_data():
 def auth_header():
     """Valid Authorization header with Bearer token."""
     return {"Authorization": "Bearer eyJhbGciOiJSUzI1NiJ9.test.token"}
+
+
+@pytest.fixture
+def authenticate_as_project():
+    """Skips authentication and returns a mock authenticated project."""
+    from pia.main import app, authenticate
+
+    mock_project = Project(
+        project_id="github-project",
+        issuer="https://token.actions.githubusercontent.com",
+        dt_parent_uuid="uuid-1",
+        required_claims={"repository": "eclipse-test/repo"},
+    )
+
+    app.dependency_overrides[authenticate] = lambda: mock_project
+    yield
+    app.dependency_overrides.clear()
 
 
 class TestUploadSBOMEndpoint:
@@ -101,7 +119,9 @@ class TestUploadSBOMEndpoint:
         assert response.status_code == 422
         assert b"JSON" in response.content or b"json" in response.content
 
-    def test_upload_missing_field(self, client, valid_request_data, auth_header):
+    def test_upload_missing_field(
+        self, client, valid_request_data, auth_header, authenticate_as_project
+    ):
         """Test error with missing required field."""
         del valid_request_data["product_name"]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,14 +1,19 @@
 """Tests for api module."""
 
+import asyncio
 from unittest.mock import Mock, patch
 
 import jwt
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from pia.dependencytrack import DependencyTrackError
 from pia.models import Project
 from pia.oidc import TokenVerificationError
+
+GITHUB_ISSUER = "https://token.actions.githubusercontent.com"
+BEARER_TOKEN = "Bearer eyJhbGciOiJSUzI1NiJ9.test.token"
 
 
 @pytest.fixture
@@ -65,186 +70,134 @@ def authenticate_as_project():
     app.dependency_overrides.clear()
 
 
+@pytest.mark.usefixtures("setup_env")
+class TestAuthenticate:
+    """Tests for the authenticate dependency, called as a regular function."""
+
+    def _call(self, authorization, projects):
+        from pia.main import authenticate
+
+        return asyncio.run(authenticate(authorization, projects))
+
+    def test_invalid_authorization_header(self, projects):
+        """Error when Authorization header doesn't start with 'Bearer '."""
+        with pytest.raises(HTTPException) as exc:
+            self._call("Basic invalid", projects)
+        assert exc.value.status_code == 401
+        assert "Invalid Authorization header format" in exc.value.detail
+
+    @patch("pia.main.jwt.decode")
+    def test_token_decode_fails(self, mock_decode, projects):
+        """Error when initial token decode fails."""
+        mock_decode.side_effect = jwt.PyJWTError()
+        with pytest.raises(HTTPException) as exc:
+            self._call(BEARER_TOKEN, projects)
+        assert exc.value.status_code == 401
+        assert "Invalid token" in exc.value.detail
+
+    @patch("pia.main.jwt.decode")
+    def test_issuer_not_allowed(self, mock_decode, projects):
+        """Error when issuer is not registered with any project."""
+        mock_decode.return_value = {"iss": "https://wrong-issuer.com"}
+        with pytest.raises(HTTPException) as exc:
+            self._call(BEARER_TOKEN, projects)
+        assert exc.value.status_code == 401
+        assert "Issuer not allowed" in exc.value.detail
+
+    @patch("pia.main.oidc.verify_token")
+    @patch("pia.main.jwt.decode")
+    def test_token_verification_fails(self, mock_decode, mock_verify, projects):
+        """Error when token signature verification fails."""
+        mock_decode.return_value = {"iss": GITHUB_ISSUER}
+        mock_verify.side_effect = TokenVerificationError()
+        with pytest.raises(HTTPException) as exc:
+            self._call(BEARER_TOKEN, projects)
+        assert exc.value.status_code == 401
+        assert "Token verification failed" in exc.value.detail
+
+    @patch("pia.main.oidc.verify_token")
+    @patch("pia.main.jwt.decode")
+    def test_no_matching_project(self, mock_decode, mock_verify, projects):
+        """Error when no project matches the verified token claims."""
+        mock_decode.return_value = {"iss": GITHUB_ISSUER}
+        mock_verify.return_value = {
+            "iss": GITHUB_ISSUER,
+            "repository": "wrong/repo",
+        }
+        with pytest.raises(HTTPException) as exc:
+            self._call(BEARER_TOKEN, projects)
+        assert exc.value.status_code == 401
+        assert "No matching project found for token claims" in exc.value.detail
+
+    @patch("pia.main.oidc.verify_token")
+    @patch("pia.main.jwt.decode")
+    def test_success(self, mock_decode, mock_verify, projects):
+        """Successful authentication returns the matched project."""
+        mock_decode.return_value = {"iss": GITHUB_ISSUER}
+        mock_verify.return_value = {
+            "iss": GITHUB_ISSUER,
+            "repository": "eclipse-test/repo",
+        }
+        result = self._call(BEARER_TOKEN, projects)
+        assert result.project_id == "github-project"
+
+
 class TestUploadSBOMEndpoint:
     """Tests for /v1/upload/sbom endpoint."""
 
     @patch("pia.main.dependencytrack.upload_sbom")
-    @patch("pia.main.oidc.verify_token")
-    @patch("pia.main.jwt.decode")
     def test_upload_success(
         self,
-        mock_decode,
-        mock_verify,
         mock_upload,
         client,
         valid_request_data,
-        auth_header,
+        authenticate_as_project,
     ):
         """Test successful SBOM upload."""
-
-        # Mock token decode
-        mock_decode.return_value = {
-            "iss": "https://token.actions.githubusercontent.com"
-        }
-
-        # Mock token verification
-        mock_verify.return_value = {
-            "iss": "https://token.actions.githubusercontent.com",
-            "repository": "eclipse-test/repo",
-        }
-
-        # Mock DT upload
         mock_dt_response = Mock()
         mock_dt_response.status_code = 200
         mock_dt_response.content = b"content"
         mock_upload.return_value = mock_dt_response
 
-        response = client.post(
-            "/v1/upload/sbom", json=valid_request_data, headers=auth_header
-        )
+        response = client.post("/v1/upload/sbom", json=valid_request_data)
 
-        # Assert response was correctly crafted from dt response
         assert response.status_code == 200
         assert response.content == b"content"
         assert response.headers["content-type"] == "application/json"
 
-    def test_upload_invalid_json(self, client, auth_header):
+    def test_upload_invalid_json(self, client, authenticate_as_project):
         """Test error with invalid JSON."""
         response = client.post(
             "/v1/upload/sbom",
             content=b"not-json",
-            headers=auth_header,
         )
 
         assert response.status_code == 422
         assert b"JSON" in response.content or b"json" in response.content
 
     def test_upload_missing_field(
-        self, client, valid_request_data, auth_header, authenticate_as_project
+        self, client, valid_request_data, authenticate_as_project
     ):
         """Test error with missing required field."""
         del valid_request_data["product_name"]
 
-        response = client.post(
-            "/v1/upload/sbom", json=valid_request_data, headers=auth_header
-        )
+        response = client.post("/v1/upload/sbom", json=valid_request_data)
 
         assert response.status_code == 422
         assert b"product_name" in response.content
 
-    def test_upload_missing_authorization_header(self, client, valid_request_data):
-        """Test error when Authorization header is missing."""
-        response = client.post("/v1/upload/sbom", json=valid_request_data)
-
-        assert response.status_code == 422
-
-    def test_upload_invalid_authorization_header(self, client, valid_request_data):
-        """Test error when Authorization header format is invalid."""
-        response = client.post(
-            "/v1/upload/sbom",
-            json=valid_request_data,
-            headers={"Authorization": "Basic invalid"},
-        )
-
-        assert response.status_code == 401
-        assert b"Invalid Authorization header format" in response.content
-
-    @patch("pia.main.jwt.decode")
-    def test_upload_issuer_not_allowed(
-        self, mock_decode, client, valid_request_data, auth_header
-    ):
-        """Test error when issuer not allowed for project."""
-        mock_decode.return_value = {"iss": "https://wrong-issuer.com"}
-
-        response = client.post(
-            "/v1/upload/sbom", json=valid_request_data, headers=auth_header
-        )
-
-        assert response.status_code == 401
-        assert b"Issuer not allowed" in response.content
-
-    @patch("pia.main.jwt.decode")
-    def test_upload_token_decode_fails(
-        self, mock_decode, client, valid_request_data, auth_header
-    ):
-        """Test error when initial token decode fails."""
-        mock_decode.side_effect = jwt.PyJWTError()
-
-        response = client.post(
-            "/v1/upload/sbom", json=valid_request_data, headers=auth_header
-        )
-
-        assert response.status_code == 401
-        assert b"Invalid token" in response.content
-
-    @patch("pia.main.jwt.decode")
-    @patch("pia.main.oidc.verify_token")
-    def test_upload_token_verification_fails(
-        self, mock_verify, mock_decode, client, valid_request_data, auth_header
-    ):
-        """Test error when token verification fails."""
-        mock_decode.return_value = {
-            "iss": "https://token.actions.githubusercontent.com"
-        }
-        mock_verify.side_effect = TokenVerificationError()
-
-        response = client.post(
-            "/v1/upload/sbom", json=valid_request_data, headers=auth_header
-        )
-
-        assert response.status_code == 401
-        assert b"Token verification failed" in response.content
-
-    @patch("pia.main.jwt.decode")
-    @patch("pia.main.oidc.verify_token")
-    def test_upload_no_matching_project(
-        self, mock_verify, mock_decode, client, valid_request_data, auth_header
-    ):
-        """Test error when no project matches the verified token claims."""
-        mock_decode.return_value = {
-            "iss": "https://token.actions.githubusercontent.com"
-        }
-
-        # Claims don't match any project's required claims
-        mock_verify.return_value = {
-            "iss": "https://token.actions.githubusercontent.com",
-            "repository": "wrong/repo",
-        }
-
-        response = client.post(
-            "/v1/upload/sbom", json=valid_request_data, headers=auth_header
-        )
-
-        assert response.status_code == 401
-        assert b"No matching project found for token claims" in response.content
-
     @patch("pia.main.dependencytrack.upload_sbom")
-    @patch("pia.main.jwt.decode")
-    @patch("pia.main.oidc.verify_token")
     def test_upload_dt_error(
         self,
-        mock_verify,
-        mock_decode,
         mock_upload,
         client,
         valid_request_data,
-        auth_header,
+        authenticate_as_project,
     ):
         """Test error when DependencyTrack upload fails."""
-        mock_decode.return_value = {
-            "iss": "https://token.actions.githubusercontent.com"
-        }
-
-        mock_verify.return_value = {
-            "iss": "https://token.actions.githubusercontent.com",
-            "repository": "eclipse-test/repo",
-        }
-
         mock_upload.side_effect = DependencyTrackError()
 
-        response = client.post(
-            "/v1/upload/sbom", json=valid_request_data, headers=auth_header
-        )
+        response = client.post("/v1/upload/sbom", json=valid_request_data)
 
         assert response.status_code == 502
         assert b"Failed to upload to DependencyTrack" in response.content


### PR DESCRIPTION
Fixes #7

The OIDC authentication flow is not specific to the SBOM upload and
may be re-used for other endpoints. Furthermore, separating auth and
sbom upload handling makes testing easier.

**Change details:**

* Extract OIDC authentication logic from `upload_sbom` into a standalone
  `authenticate()` dependency function, which returns an authenticated
   Project to its dependent.

* Further encapsulate get_projects() in a dependency function used by
 ` authenticate()`. This decouples authentication from `request.app.state` so
  it can be unit-tested as a regular async function.

* Simplify tests

**Docs:**
https://fastapi.tiangolo.com/tutorial/dependencies/
https://fastapi.tiangolo.com/advanced/testing-dependencies

**Note to reviewer:**
There is barely new implementation code. The auth logic in main.py is completely untouched. And all but one (see 2nd commit) test cases are left intact, and only tweaked to call auth as function and not as endpoint. The only new original code is the usage of the [Dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) idiom and a bit of new test scaffolding.  
