### PR TITLE
Add zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
fixes #11 

Uses zizmor via GitHub Action as recommended:
https://docs.zizmor.sh/integrations/#via-zizmorcorezizmor-action

Use GitHub Action with Github Advanced Security as recommended: https://github.com/zizmorcore/zizmor-action#usage-with-github-advanced-security-recommended

Workflow file is copied from the zizmor action docs and adapted for our use case.