### PR TITLE
Fail CI if uv.lock is out of sync with pyproject.toml (#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867
 
-    - name: Install dependencies
-      run: uv sync --all-extras
+    - name: Install dependencies (fails if uv.lock is out of sync)
+      run: uv sync --locked --all-extras
 
     - name: Run linter
       run: make lint


### PR DESCRIPTION
Add `--locked` to the existing `uv sync` install step. The flag asserts that `uv.lock` would remain unchanged by the sync; if pyproject.toml has been modified without a corresponding lock regeneration, the step exits non-zero before any other `uv` command runs, so nothing can silently auto-sync the lock and mask the drift.

fixes #25 