### PR TITLE
Escape unverified JWT `iss` claim in log output

### DIFF
--- a/pia/main.py
+++ b/pia/main.py
@@ -105,15 +105,15 @@ async def authenticate(
         logger.warning(f"Token decode failed: {e}")
         _401("Invalid token")
 
-    logger.info(f"Unverified issuer extracted: {unverified_issuer}")
+    logger.info(f"Unverified issuer extracted: {unverified_issuer!a}")
 
     # Inexpensive pre-verification check
     if not is_issuer_known(unverified_issuer):
-        logger.warning(f"Issuer {unverified_issuer} not allowed")
+        logger.warning(f"Issuer {unverified_issuer!a} not allowed")
         _401("Issuer not allowed")
 
     logger.info(
-        f"Issuer '{unverified_issuer}' is allowed, proceeding with token verification"
+        f"Issuer '{unverified_issuer!a}' is allowed, proceeding with token verification"
     )
     # Full token verification
     try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 """Tests for api module."""
 
 import asyncio
+import logging
 from unittest.mock import Mock, patch
 
 import jwt
@@ -304,3 +305,33 @@ class TestHealthEndpoints:
         response = client.get("/livez")
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.usefixtures("setup_env")
+class TestNewlineEscaping:
+    """Regression for escaping newlines when logging unverified JWT `iss`."""
+
+    @patch("pia.main.jwt.decode")
+    def test_newline_in_unverified_iss_does_not_split_records(
+        self, mock_decode, seed_db, caplog
+    ):
+        from pia.main import authenticate
+
+        forged_iss = (
+            "https://x.example\n"
+            "2026-04-27 09:00:00,000 - pia.main - INFO - forged record"
+        )
+        mock_decode.return_value = {"iss": forged_iss}
+
+        with (
+            caplog.at_level(logging.INFO, logger="pia.main"),
+            pytest.raises(HTTPException),
+        ):
+            asyncio.run(authenticate(BEARER_TOKEN, seed_db))
+
+        for record in caplog.records:
+            msg = record.getMessage()
+            assert "\n" not in msg, f"newline leaked into: {msg!r}"
+        assert any("\\n" in r.getMessage() for r in caplog.records), (
+            "expected escaped newline somewhere in captured logs"
+        )


### PR DESCRIPTION
Without sanitisation, newlines  in `iss` could forge log records on the configured single-line text formatter. As fix we format the value with `!a` (ascii) at the pre-verification sinks and add a regression test.