### PR TITLE
Validate issuer/URL by scheme and host instead of string prefix

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -154,7 +154,8 @@ sequenceDiagram
    2. Extract issuer
    3. Verify issuer is known
       - GitHub: Full match: `https://token.actions.githubusercontent.com`
-      - Jenkins: Prefix match: `https://ci.eclipse.org`
+      - Jenkins: Parse the issuer as a URL and require an `https` scheme with
+        the host exactly equal to `ci.eclipse.org`
 3. Token Key Discovery
    1. Fetch OIDC configuration from `{issuer}/.well-known/openid-configuration`
    2. Extract `jwks_uri` from configuration

--- a/pia/cli.py
+++ b/pia/cli.py
@@ -42,7 +42,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from .models import (
-    JENKINS_ISSUER_PREFIX,
+    GITHUB_BASE_URL,
+    JENKINS_ISSUER_BASE_URL,
     DependencyTrackProject,
     EclipseFoundationProject,
     GitHubWorkload,
@@ -130,11 +131,12 @@ def add_workload(ef_project_id: str, url: str, dry_run: bool) -> None:
     """Register a GitHub or Jenkins workload for an Eclipse Foundation project.
 
     URL type is determined by its value: github.com URLs create a GitHubWorkload,
-    URLs starting with the Jenkins issuer prefix create a JenkinsWorkload with the
-    URL as issuer. Any other URL is rejected.
+    ci.eclipse.org URLs create a JenkinsWorkload with the URL as issuer. Both are
+    matched on the URL's scheme and host. Any other URL is rejected.
     """
     parsed = urlparse(url)
-    if parsed.netloc == "github.com":
+    base_url = f"{parsed.scheme}://{parsed.hostname}"
+    if base_url == GITHUB_BASE_URL:
         path_parts = parsed.path.strip("/").split("/")
         if len(path_parts) != 2 or not all(path_parts):
             raise click.ClickException(f"GitHub URL must include owner/repo: {url}")
@@ -150,15 +152,15 @@ def add_workload(ef_project_id: str, url: str, dry_run: bool) -> None:
             f"Prepared GitHubWorkload(ef_project_id={ef_project_id!r}, "
             f"repo_owner={owner!r}, repo_name={repo!r}, repo_owner_id={owner_id})"
         )
-    elif url.startswith(JENKINS_ISSUER_PREFIX):
+    elif base_url == JENKINS_ISSUER_BASE_URL:
         workload = JenkinsWorkload(ef_project_id=ef_project_id, issuer=url)
         logger.info(
             f"Prepared JenkinsWorkload(ef_project_id={ef_project_id!r}, issuer={url!r})"
         )
     else:
         raise click.ClickException(
-            f"URL must be a GitHub repo URL or start with {JENKINS_ISSUER_PREFIX!r}: "
-            f"{url}"
+            f"URL must be a {GITHUB_BASE_URL} repo URL or a "
+            f"{JENKINS_ISSUER_BASE_URL} issuer URL: {url}"
         )
 
     with _make_session() as session:

--- a/pia/models.py
+++ b/pia/models.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 from sqlalchemy import ForeignKey, Select, String, UniqueConstraint, select
@@ -13,8 +14,11 @@ logger = logging.getLogger(__name__)
 GITHUB_ISSUER = "https://token.actions.githubusercontent.com"
 """OIDC issuer for GitHub Actions tokens. Constant across all GitHub workloads."""
 
-JENKINS_ISSUER_PREFIX = "https://ci.eclipse.org"
-"""Prefix used for early validation of Jenkins issuer URLs."""
+GITHUB_BASE_URL = "https://github.com"
+"""Scheme and host of the GitHub repo URLs accepted when registering workloads."""
+
+JENKINS_ISSUER_BASE_URL = "https://ci.eclipse.org"
+"""Scheme and host every Jenkins issuer URL must have."""
 
 GITHUB_ALLOWED_EVENT_NAMES = frozenset({"push", "workflow_dispatch"})
 """Allowed values for the GitHub OIDC token's `event_name` claim.
@@ -131,12 +135,14 @@ def is_issuer_known(issuer: str) -> bool:
     """Check if issuer is generally known to PIA.
 
     GitHub: issuer must equal GITHUB_ISSUER
-    Jenkins: issuer must start with JENKINS_ISSUER_PREFIX
+    Jenkins: issuer's scheme and host must equal JENKINS_ISSUER_BASE_URL
+
     """
     if issuer == GITHUB_ISSUER:
         return True
 
-    return issuer.startswith(JENKINS_ISSUER_PREFIX)
+    parsed = urlparse(issuer)
+    return f"{parsed.scheme}://{parsed.hostname}" == JENKINS_ISSUER_BASE_URL
 
 
 def find_workload_by_claims(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,6 +141,38 @@ def test_add_workload_invalid_github_url(runner):
     assert "owner/repo" in result.output
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        # GitHub host disguised via userinfo / suffix, or wrong scheme.
+        "https://github.com@evil.example/eclipse-foo/repo",
+        "https://github.com.evil.example/eclipse-foo/repo",
+        "http://github.com/eclipse-foo/repo",
+        # Jenkins host disguised via userinfo / suffix, or wrong scheme.
+        "https://ci.eclipse.org@evil.example/eclipse-bar/oidc",
+        "https://ci.eclipse.org.evil.example/eclipse-bar/oidc",
+        "http://ci.eclipse.org/eclipse-bar/oidc",
+    ],
+)
+def test_add_workload_rejects_disguised_or_non_https_host(
+    runner, session_factory, monkeypatch, url
+):
+    # A disguised host must be rejected during URL validation, before any
+    # network call (e.g. resolving the GitHub owner id) or DB write.
+    def fail(*a, **kw):
+        raise AssertionError("network must not be touched for a rejected URL")
+
+    monkeypatch.setattr(cli_module.requests, "get", fail)
+
+    result = runner.invoke(cli_module.cli, ["add-workload", "eclipse-foo", url])
+
+    assert result.exit_code != 0
+    assert "URL must be" in result.output
+    with session_factory() as s:
+        assert s.query(GitHubWorkload).count() == 0
+        assert s.query(JenkinsWorkload).count() == 0
+
+
 def test_missing_database_url_fails_early(runner, monkeypatch):
     """Without PIA_DATABASE_URL the cli group exits before any subcommand runs."""
     monkeypatch.delenv("PIA_DATABASE_URL", raising=False)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,8 +24,34 @@ class TestIsIssuerKnown:
     def test_jenkins_issuer_known(self):
         assert is_issuer_known("https://ci.eclipse.org/eclipse-other/oidc")
 
+    def test_jenkins_issuer_bare_host_known(self):
+        assert is_issuer_known("https://ci.eclipse.org")
+
     def test_arbitrary_issuer_unknown(self):
         assert not is_issuer_known("https://attacker.com")
+
+    @pytest.mark.parametrize(
+        "issuer",
+        [
+            # Userinfo before "@": the real host is other.host, not ci.eclipse.org.
+            "https://ci.eclipse.org@other.host",
+            "https://ci.eclipse.org@127.0.0.1:8888",
+            # Suffix on the host: ci.eclipse.org.other.host is a different host.
+            "https://ci.eclipse.org.other.host",
+            "https://ci.eclipse.org.other.host/eclipse-x/oidc",
+            # Host is only a prefix substring, not the whole host.
+            "https://ci.eclipse.org.evil.example/.well-known/openid-configuration",
+        ],
+    )
+    def test_issuer_resolving_to_other_host_unknown(self, issuer):
+        assert not is_issuer_known(issuer)
+
+    def test_non_https_jenkins_issuer_unknown(self):
+        assert not is_issuer_known("http://ci.eclipse.org/eclipse-other/oidc")
+
+    def test_malformed_issuer_unknown(self):
+        assert not is_issuer_known("ci.eclipse.org")
+        assert not is_issuer_known("not a url")
 
 
 class TestFindWorkloadByClaims:


### PR DESCRIPTION
`is_issuer_known` accepted any issuer that started with the expected string "https://ci.eclipse.org". A string-prefix check treats the issuer as opaque text, so URLs that only begin with those characters but resolve to a different host were accepted -- e.g. a userinfo form ("https://ci.eclipse.org@other.host") or a suffix form ("https://ci.eclipse.org.other.host"). **The issuer is then used for OIDC discovery, so it must genuinely point at the expected host.**

Match issuers/URLs on their parsed scheme and host (`f"{scheme}://{hostname}"`) against a base-URL constant:

- `models.is_issuer_known`: compare against `JENKINS_ISSUER_BASE_URL`, mirroring how the GitHub issuer is matched against `GITHUB_ISSUER`.
- `cli add-workload`: apply the same scheme+host comparison to both the GitHub (`GITHUB_BASE_URL`) and Jenkins (`JENKINS_ISSUER_BASE_URL`) cases, replacing the bare netloc equality and startswith checks. This also enforces the https scheme on the GitHub repo URL in the cli. The input to the cli is trustworthy, but it doesn't hurt to check to avoid foot-guns.

Rename the constant `JENKINS_ISSUER_PREFIX` to `JENKINS_ISSUER_BASE_URL` and add `GITHUB_BASE_URL`.

Add tests for the userinfo/suffix host constructions, non-https and malformed issuers, and the disguised/non-https URLs in the CLI (asserting no network call or DB write happens for a rejected URL). Update the authentication flow in DESIGN.md to describe host-based validation.


Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com> (reviewed, edited, and signed off by me)