### PR TITLE
Fix "server closed connection unexpectedly" db issue

### DIFF
--- a/pia/main.py
+++ b/pia/main.py
@@ -38,7 +38,11 @@ logger.info("PIA application settings loaded successfully")
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize database engine and session factory on app startup."""
-    engine = create_engine(settings.database_url)
+    engine = create_engine(
+        settings.database_url,
+        pool_pre_ping=True,
+        pool_recycle=1800,
+    )
     app.state.session_factory = sessionmaker(bind=engine)
     logger.info("Database engine and session factory initialized")
     yield


### PR DESCRIPTION
The engine outlives individual requests, so pooled connections can be dropped server-side (idle timeouts, firewall reaps, failovers) while still sitting in the pool. pool_pre_ping validates a connection before use and transparently reconnects if it is dead; pool_recycle bounds connection age so they are refreshed before common idle-timeout windows. Without these, a stale connection surfaces as "server closed the connection unexpectedly".

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>