### PR TITLE
Enforce product_name -> one DT project per EF project

### DIFF
--- a/alembic/versions/777888973479_unique_dt_project_per_ef_project_id_and_.py
+++ b/alembic/versions/777888973479_unique_dt_project_per_ef_project_id_and_.py
@@ -1,0 +1,51 @@
+"""unique dt project per ef_project_id and name
+
+Revision ID: 777888973479
+Revises: 844bb24a18ad
+Create Date: 2026-07-09 14:02:51.244341
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '777888973479'
+down_revision: Union[str, Sequence[str], None] = '844bb24a18ad'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Enforce that a product_name maps to one DT project per EF project.
+
+    Replaces the (name, parent_uuid) uniqueness with (ef_project_id, name), which
+    is what the runtime relies on (find_dt_project resolves the upload target by
+    ef_project_id + name via scalar_one_or_none()). Fails if existing rows already
+    violate it — that is intentional; such data was already ambiguous.
+    """
+    op.drop_constraint(
+        "dependency_track_projects_name_parent_uuid_key",
+        "dependency_track_projects",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_dependency_track_projects_ef_project_id_name",
+        "dependency_track_projects",
+        ["ef_project_id", "name"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(
+        "uq_dependency_track_projects_ef_project_id_name",
+        "dependency_track_projects",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "dependency_track_projects_name_parent_uuid_key",
+        "dependency_track_projects",
+        ["name", "parent_uuid"],
+    )

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -261,7 +261,8 @@ A CI/CD entity that can upload SBOMs. Uses joined-table inheritance with a
 
 #### GitHubWorkload (extends Workload)
 Issuer is always `https://token.actions.githubusercontent.com` (constant, not
-stored).
+stored). Unique on `(repo_owner, repo_name, repo_owner_id)` — not scoped by
+`ef_project_id`, so a repository maps to a single workload.
 
 | Column | Type | Notes |
 |--------|------|-------|
@@ -271,7 +272,8 @@ stored).
 | `repo_owner_id` | String | GitHub numeric owner ID |
 
 #### JenkinsWorkload (extends Workload)
-Each Jenkins workload has a distinct issuer URL.
+Each Jenkins workload has a distinct issuer URL (`issuer` is unique, not scoped
+by `ef_project_id`).
 
 | Column | Type | Notes |
 |--------|------|-------|
@@ -279,7 +281,9 @@ Each Jenkins workload has a distinct issuer URL.
 | `issuer` | String | OIDC issuer URL (e.g. `https://ci.eclipse.org/<name>/oidc`) |
 
 #### DependencyTrackProject
-A DependencyTrack target for SBOM uploads.
+A DependencyTrack target for SBOM uploads. Unique on `(ef_project_id, name)`, so a
+`product_name` resolves to exactly one DependencyTrack project within an Eclipse
+Foundation project.
 
 | Column | Type | Notes |
 |--------|------|-------|
@@ -293,6 +297,22 @@ A DependencyTrack target for SBOM uploads.
 The Eclipse Foundation project id is the authorization boundary. Any workload
 can upload SBOMs for any DependencyTrack project that shares the same Eclipse
 Foundation project id.
+
+A workload identity — a GitHub repository (`repo_owner`, `repo_name`,
+`repo_owner_id`) or a Jenkins `issuer` — belongs to **exactly one** Eclipse
+Foundation project. This is a design choice, enforced by the workload uniqueness
+constraints above (which are deliberately *not* scoped by `ef_project_id`): the
+OIDC token carries only the workload identity, so `find_workload_by_claims`
+resolves it to a single workload and hence a single EF-project scope. Within that
+scope the target DependencyTrack project is selected by `product_name`, and the
+`(ef_project_id, name)` uniqueness constraint makes that selection unambiguous.
+
+Note that authentication does not *require* the one-to-one workload↔project
+relationship — a one-to-many model could authenticate the same identity for
+several projects. The invariant that must hold for correctness is narrower: a
+`product_name` must resolve to a single DependencyTrack project within the
+authenticated scope. The current model satisfies it the simple way (one workload
+→ one EF project → per-project unique `product_name`).
 
 
 ## 5. Implementation Details

--- a/pia/models.py
+++ b/pia/models.py
@@ -128,7 +128,11 @@ class DependencyTrackProject(Base):
     name: Mapped[str] = mapped_column(String)
     parent_uuid: Mapped[str] = mapped_column(String)
 
-    __table_args__ = (UniqueConstraint("name", "parent_uuid"),)
+    # A product_name must map to exactly one DependencyTrack project within an
+    # Eclipse Foundation project: the runtime resolves the upload target with
+    # find_dt_project(ef_project_id, name) via scalar_one_or_none(), so
+    # (ef_project_id, name) must be unique.
+    __table_args__ = (UniqueConstraint("ef_project_id", "name"),)
 
 
 def is_issuer_known(issuer: str) -> bool:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,9 +2,12 @@
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
 
 from pia.models import (
+    DependencyTrackProject,
     DependencyTrackUploadPayload,
+    EclipseFoundationProject,
     GitHubWorkload,
     JenkinsWorkload,
     PiaUploadPayload,
@@ -172,6 +175,44 @@ class TestFindDtProject:
     def test_wrong_name(self, seed_db):
         dt_project = find_dt_project(seed_db, "eclipse-test", "no-such-product")
         assert dt_project is None
+
+    def test_name_unique_within_ef_project(self, session):
+        """(ef_project_id, name) is unique, so a product_name maps to one project."""
+        session.add(EclipseFoundationProject(id="eclipse-test"))
+        session.add(
+            DependencyTrackProject(
+                ef_project_id="eclipse-test", name="server", parent_uuid="uuid-a"
+            )
+        )
+        session.add(
+            DependencyTrackProject(
+                ef_project_id="eclipse-test", name="server", parent_uuid="uuid-b"
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+    def test_same_name_allowed_in_different_ef_projects(self, session):
+        """The same product_name may exist under different EF projects."""
+        session.add_all(
+            [
+                EclipseFoundationProject(id="eclipse-test"),
+                EclipseFoundationProject(id="eclipse-other"),
+                DependencyTrackProject(
+                    ef_project_id="eclipse-test", name="server", parent_uuid="uuid-a"
+                ),
+                DependencyTrackProject(
+                    ef_project_id="eclipse-other", name="server", parent_uuid="uuid-b"
+                ),
+            ]
+        )
+        session.commit()  # no IntegrityError
+        assert (
+            find_dt_project(session, "eclipse-test", "server").parent_uuid == "uuid-a"
+        )
+        assert (
+            find_dt_project(session, "eclipse-other", "server").parent_uuid == "uuid-b"
+        )
 
 
 class TestUploadSBOMPayload:


### PR DESCRIPTION
Change the DependencyTrackProject uniqueness from (name, parent_uuid) to (ef_project_id, name), which is the invariant the runtime relies on: the upload target is resolved by find_dt_project(ef_project_id, name) via scalar_one_or_none(). Adds an Alembic migration for the constraint swap (reversible) and tests that a duplicate (ef_project_id, name) is rejected while the same name under different EF projects is allowed.

Also document the model in DESIGN.md: the workload uniqueness constraints (not scoped by ef_project_id) and the DT (ef_project_id, name) constraint, and expand the Authorization Boundary section to frame one-workload-per-EF-project as a design choice while the actual correctness invariant is that product_name resolves to a single DT project within the authenticated scope.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>