### PR TITLE
Add `pia sync` and `pia create-dt-projects` CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ Use `pia create-dt-projects` to ensure existence of DependencyTrack targets
 prior to syncing.
 
 See [CLI section of the design doc](docs/DESIGN.md#55-cli-tool) or run with
-`--help` for more infos.
+`--help` for more info.

--- a/README.md
+++ b/README.md
@@ -65,3 +65,13 @@ version control.
 ```shell
 docker compose run --rm pia alembic revision --autogenerate --message "MESSAGE"
 ```
+
+### Managing Authorizations
+
+Project authorizations (workloads and DependencyTrack targets) live in the
+database and are managed declaratively: reconcile the whole set from a curated
+file with `pia sync`. See [CLI section of the design doc]
+(docs/DESIGN.md#55-cli-tool) or with  `--help` for more infos.
+
+See [CLI section of the design doc](docs/DESIGN.md#55-cli-tool) or run with
+`--help` for more infos.

--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ docker compose run --rm pia alembic revision --autogenerate --message "MESSAGE"
 
 Project authorizations (workloads and DependencyTrack targets) live in the
 database and are managed declaratively: reconcile the whole set from a curated
-file with `pia sync`. See [CLI section of the design doc]
-(docs/DESIGN.md#55-cli-tool) or with  `--help` for more infos.
+file with `pia sync`.
+
+Use `pia create-dt-projects` to ensure existence of DependencyTrack targets
+prior to syncing.
 
 See [CLI section of the design doc](docs/DESIGN.md#55-cli-tool) or run with
 `--help` for more infos.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -322,6 +322,7 @@ project bound to a single EF project.
 - **JWT Library**: `PyJWT` with `cryptography` support
   - Handles token parsing, validation, and signature verification
   - Includes `PyJWKClient` for JWKS key fetching
+- **CLI**: `click`
 - **Testing**: `pytest`
 - **Linting**: `ruff`
 - **Python Project Management**: `uv`
@@ -340,6 +341,8 @@ project bound to a single EF project.
   - Pydantic request models: `PiaUploadPayload`, `DependencyTrackUploadPayload`
 - `oidc.py`: OIDC token validation and signature verification using PyJWT
 - `dependencytrack.py`: DependencyTrack API upload client for SBOMs
+- `cli.py`: Management CLI for registering Workloads and DependencyTrackProjects
+  (see section 5.5)
 
 ### 5.3 Error Handling
 
@@ -369,6 +372,36 @@ Metrics to track:
 - Token verification time
 - DependencyTrack upload time
 - Total API response time
+
+### 5.5 CLI Tool
+
+PIA includes a management CLI (`pia`) for managing project authorizations. It is
+installed as a console entry point via `pyproject.toml` and connects to the DB
+using the `PIA_DATABASE_URL` environment variable, e.g.
+`postgresql://user:secret@1.2.3.4:5432/pia`.
+
+#### `pia sync`
+
+Reconciles the whole authorization state to match a curated projects file. The
+file lists Eclipse Foundation projects, each with a flat list of workload URLs
+(GitHub repo or Jenkins instance URL — classified by host) and a list of
+DependencyTrack `(parent, project)` mappings. `sync` resolves the external
+data (GitHub owner ids, DependencyTrack child UUIDs), diffs the desired state
+against the database, prints a plan, and applies it so the database matches the
+file.
+
+Example projects file:
+
+```yaml
+projects:
+  - id: technology.foo
+    workloads:
+      - https://github.com/eclipse-foo/repo
+      - https://ci.eclipse.org/foo
+    dependency_track:
+      - parent: "Eclipse Foo"
+        project: foo-server
+```
 
 ## 6. Security Considerations
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -403,6 +403,13 @@ projects:
         project: foo-server
 ```
 
+#### `pia create-dt-projects`
+
+Ensures every `(parent, project)` DependencyTrack mapping in the curated file
+exists on DependencyTrack, creating any missing root/child projects. This is a
+provisioning step only — it does **not** touch the PIA database — so run it before
+`pia sync` whenever a file introduces new DependencyTrack targets.
+
 ## 6. Security Considerations
 
 ### 6.1 Token Validation

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -385,7 +385,7 @@ using the `PIA_DATABASE_URL` environment variable, e.g.
 Reconciles the whole authorization state to match a curated projects file. The
 file lists Eclipse Foundation projects, each with a flat list of workload URLs
 (GitHub repo or Jenkins instance URL — classified by host) and a list of
-DependencyTrack `(parent, project)` mappings. `sync` resolves the external
+DependencyTrack `(project, product)` mappings. `sync` resolves the external
 data (GitHub owner ids, DependencyTrack child UUIDs), diffs the desired state
 against the database, prints a plan, and applies it so the database matches the
 file.
@@ -399,13 +399,13 @@ projects:
       - https://github.com/eclipse-foo/repo
       - https://ci.eclipse.org/foo
     dependency_track:
-      - parent: "Eclipse Foo"
-        project: foo-server
+      - project: "Eclipse Foo"
+        product: foo-server
 ```
 
 #### `pia create-dt-projects`
 
-Ensures every `(parent, project)` DependencyTrack mapping in the curated file
+Ensures every `(project, product)` DependencyTrack mapping in the curated file
 exists on DependencyTrack, creating any missing root/child projects. This is a
 provisioning step only — it does **not** touch the PIA database — so run it before
 `pia sync` whenever a file introduces new DependencyTrack targets.

--- a/pia/cli.py
+++ b/pia/cli.py
@@ -4,6 +4,8 @@ Subcommands
 -----------
 - sync: Reconcile all project authorizations from a curated file into the
   database (create/update/delete).
+- create-dt-projects: Create the DependencyTrack projects referenced by a curated
+  file (provisioning only; no database access).
 
 Usage Example
 -------------
@@ -11,6 +13,9 @@ Usage Example
     PIA_DEPENDENCY_TRACK_API_KEY=<API key with VIEW_PORTFOLIO permission> \
     PIA_GITHUB_TOKEN=<optional token with public read permission for rate limit> \
         uv run pia sync projects.yaml --dt-url https://sbom.eclipse.org --dry-run
+
+    PIA_DEPENDENCY_TRACK_API_KEY=<API key with PORTFOLIO_MANAGEMENT permission> \
+        uv run pia create-dt-projects projects.yaml --dt-url https://sbom.eclipse.org
 
 """
 
@@ -25,6 +30,7 @@ from .sync import (
     apply_plan,
     build_desired,
     compute_plan,
+    ensure_dt_projects,
     format_plan,
     load_projects_file,
     validate_projects_file,
@@ -132,6 +138,41 @@ def sync(
         apply_plan(session, plan)
         session.commit()
         click.echo("Applied.")
+
+
+@cli.command("create-dt-projects")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--dt-url",
+    default=None,
+    help="DependencyTrack base URL (required). This is the base, not the "
+    "/api/v1/bom upload URL.",
+)
+def create_dt_projects(file: str, dt_url: str | None) -> None:
+    """Create the DependencyTrack projects referenced by a curated FILE.
+
+    Ensures every (parent, project) DependencyTrack mapping in the file exists,
+    creating any missing root/child projects. Provisioning only — it does not touch
+    the PIA database, so run it before `pia sync` whenever a file introduces new
+    DependencyTrack targets. Idempotent: existing projects are left as-is.
+
+    Requires --dt-url and PIA_DEPENDENCY_TRACK_API_KEY (with PORTFOLIO_MANAGEMENT
+    permission to create projects).
+    """
+    pf = load_projects_file(file)
+    validate_projects_file(pf)
+
+    dt_api_key = os.environ.get("PIA_DEPENDENCY_TRACK_API_KEY")
+    if not dt_url or not dt_api_key:
+        raise click.ClickException(
+            "--dt-url and PIA_DEPENDENCY_TRACK_API_KEY are required"
+        )
+
+    ensured = ensure_dt_projects(pf, dt_url, dt_api_key)
+    click.echo(
+        f"Ensured {len(ensured)} DependencyTrack (parent, project) mapping(s) on "
+        f"{dt_url}."
+    )
 
 
 if __name__ == "__main__":

--- a/pia/cli.py
+++ b/pia/cli.py
@@ -1,0 +1,138 @@
+"""Management CLI for PIA.
+
+Subcommands
+-----------
+- sync: Reconcile all project authorizations from a curated file into the
+  database (create/update/delete).
+
+Usage Example
+-------------
+    PIA_DATABASE_URL=postgresql://user:secret@localhost:5432/pia \
+    PIA_DEPENDENCY_TRACK_API_KEY=<API key with VIEW_PORTFOLIO permission> \
+    PIA_GITHUB_TOKEN=<optional token with public read permission for rate limit> \
+        uv run pia sync projects.yaml --dt-url https://sbom.eclipse.org --dry-run
+
+"""
+
+import logging
+import os
+
+import click
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .sync import (
+    apply_plan,
+    build_desired,
+    compute_plan,
+    format_plan,
+    load_projects_file,
+    validate_projects_file,
+)
+
+
+@click.group()
+@click.option("-v", "--verbose", is_flag=True, help="Enable debug logging.")
+def cli(verbose: bool) -> None:
+    """PIA management CLI."""
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def _make_session() -> Session:
+    engine = create_engine(os.environ["PIA_DATABASE_URL"])
+    return sessionmaker(bind=engine)()
+
+
+@cli.command("sync")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--dt-url",
+    default=None,
+    help="DependencyTrack base URL (required). This is the base, not the "
+    "/api/v1/bom upload URL.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show the plan without writing to the PIA database.",
+)
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Validate the file only; performs no database or network access.",
+)
+@click.option(
+    "--allow-db-updates-and-deletions",
+    is_flag=True,
+    help="Apply the plan even when it contains updates or deletions to existing "
+    "rows in the PIA database. Explicit intent is required to prevent accidental "
+    "deauthorization of projects.",
+)
+def sync(
+    file: str,
+    dt_url: str | None,
+    dry_run: bool,
+    check: bool,
+    allow_db_updates_and_deletions: bool,
+) -> None:
+    """Reconcile all authorizations from a curated FILE into the database.
+
+    Computes the difference between the file (the source of truth) and the
+    current database state, prints the plan, and — unless --dry-run — applies
+    it, creating, updating and deleting rows to match the file.
+
+    The DependencyTrack projects referenced by the file must already exist; a
+    missing one is an error. Run `pia create-dt-projects` first to provision them.
+
+    Requires PIA_DATABASE_URL, --dt-url, and PIA_DEPENDENCY_TRACK_API_KEY (with
+    VIEW_PORTFOLIO permission). PIA_GITHUB_TOKEN is optional and only lifts the
+    anonymous GitHub rate limit.
+    """
+    pf = load_projects_file(file)
+    validate_projects_file(pf)
+    if check:
+        click.echo(f"OK: {file} is valid ({len(pf.projects)} project(s)).")
+        return
+
+    if not os.environ.get("PIA_DATABASE_URL"):
+        raise click.ClickException("PIA_DATABASE_URL is not set")
+
+    dt_api_key = os.environ.get("PIA_DEPENDENCY_TRACK_API_KEY")
+    if not dt_url or not dt_api_key:
+        raise click.ClickException(
+            "--dt-url and PIA_DEPENDENCY_TRACK_API_KEY are required"
+        )
+
+    desired = build_desired(
+        pf,
+        dt_url=dt_url,
+        dt_api_key=dt_api_key,
+        github_token=os.environ.get("PIA_GITHUB_TOKEN"),
+    )
+
+    with _make_session() as session:
+        plan = compute_plan(session, desired)
+        click.echo(format_plan(plan))
+
+        if dry_run or plan.is_empty():
+            session.rollback()
+            return
+
+        if (plan.ef_delete or plan.deletes) and not allow_db_updates_and_deletions:
+            session.rollback()
+            raise click.ClickException(
+                "Plan contains updates and/or deletions; re-run with "
+                "--allow-db-updates-and-deletions to apply (or --dry-run to "
+                "preview)."
+            )
+
+        apply_plan(session, plan)
+        session.commit()
+        click.echo("Applied.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/pia/cli.py
+++ b/pia/cli.py
@@ -151,7 +151,7 @@ def sync(
 def create_dt_projects(file: str, dt_url: str | None) -> None:
     """Create the DependencyTrack projects referenced by a curated FILE.
 
-    Ensures every (parent, project) DependencyTrack mapping in the file exists,
+    Ensures every (project, product) DependencyTrack mapping in the file exists,
     creating any missing root/child projects. Provisioning only — it does not touch
     the PIA database, so run it before `pia sync` whenever a file introduces new
     DependencyTrack targets. Idempotent: existing projects are left as-is.
@@ -170,7 +170,7 @@ def create_dt_projects(file: str, dt_url: str | None) -> None:
 
     ensured = ensure_dt_projects(pf, dt_url, dt_api_key)
     click.echo(
-        f"Ensured {len(ensured)} DependencyTrack (parent, project) mapping(s) on "
+        f"Ensured {len(ensured)} DependencyTrack (project, product) mapping(s) on "
         f"{dt_url}."
     )
 

--- a/pia/models.py
+++ b/pia/models.py
@@ -20,6 +20,14 @@ GITHUB_BASE_URL = "https://github.com"
 JENKINS_ISSUER_BASE_URL = "https://ci.eclipse.org"
 """Scheme and host every Jenkins issuer URL must have."""
 
+JENKINS_OIDC_SUFFIX = "/oidc"
+"""Path suffix appended to a Jenkins workload URL to form its OIDC issuer.
+
+Each Eclipse Jenkins project serves its issuer at
+``https://ci.eclipse.org/<name>/oidc`` (see docs/DESIGN.md §7.2). Curated
+project files list the workload URL (``https://ci.eclipse.org/<name>``); PIA
+appends this suffix."""
+
 GITHUB_ALLOWED_EVENT_NAMES = frozenset({"push", "workflow_dispatch"})
 """Allowed values for the GitHub OIDC token's `event_name` claim.
 
@@ -49,6 +57,14 @@ class EclipseFoundationProject(Base):
     # via its `ef_project_id` foreign key. Uniqueness is implicit through the
     # single column.
     id: Mapped[str] = mapped_column(String, primary_key=True)
+
+    @property
+    def diff_key(self) -> tuple[str, ...]:
+        return (self.id,)
+
+    def __repr__(self) -> str:
+        # extra space is intentional to align with other models
+        return f"Eclipse Project  ({self.id})"
 
 
 class Workload(Base):
@@ -107,6 +123,17 @@ class GitHubWorkload(Workload):
         "polymorphic_identity": "github",
     }
 
+    @property
+    def diff_key(self) -> tuple[str, ...]:
+        return (self.ef_project_id, self.repo_owner, self.repo_name, self.repo_owner_id)
+
+    def __repr__(self) -> str:
+        # extra space is intentional to align with other models
+        return (
+            f"Github Workload  (project: {self.ef_project_id}, "
+            f"repo: {self.repo_owner}/{self.repo_name}, owner id: {self.repo_owner_id})"
+        )
+
 
 class JenkinsWorkload(Workload):
     """Jenkins workload. Each instance has a distinct issuer URL."""
@@ -121,6 +148,15 @@ class JenkinsWorkload(Workload):
     __mapper_args__ = {
         "polymorphic_identity": "jenkins",
     }
+
+    @property
+    def diff_key(self) -> tuple[str, ...]:
+        return (self.ef_project_id, self.issuer)
+
+    def __repr__(self) -> str:
+        return (
+            f"Jenkins Workload (project: {self.ef_project_id}, issuer: {self.issuer})"
+        )
 
 
 class DependencyTrackProject(Base):
@@ -150,6 +186,17 @@ class DependencyTrackProject(Base):
         # different EF projects to e.g. upload a product named "cli" or "server".
         UniqueConstraint("ef_project_id", "name"),
     )
+
+    @property
+    def diff_key(self) -> tuple[str, ...]:
+        return (self.ef_project_id, self.name, self.parent_uuid)
+
+    def __repr__(self) -> str:
+        # extra space is intentional to align with other models
+        return (
+            f"DependencyTrack  (project: {self.ef_project_id}, "
+            f"name: {self.name}, parent id: {self.parent_uuid})"
+        )
 
 
 def is_issuer_known(issuer: str) -> bool:

--- a/pia/models.py
+++ b/pia/models.py
@@ -130,7 +130,7 @@ class GitHubWorkload(Workload):
     def __repr__(self) -> str:
         # extra space is intentional to align with other models
         return (
-            f"Github Workload  (project: {self.ef_project_id}, "
+            f"GitHub Workload  (project: {self.ef_project_id}, "
             f"repo: {self.repo_owner}/{self.repo_name}, owner id: {self.repo_owner_id})"
         )
 

--- a/pia/sync.py
+++ b/pia/sync.py
@@ -204,41 +204,108 @@ def _dt_search_root_projects(
     return response.json()
 
 
+def _dt_create_project(
+    dt_url: str, name: str, api_key: str, parent_uuid: str | None = None
+) -> dict[str, Any]:
+    """Create a DependencyTrack project (root if ``parent_uuid`` is None)."""
+    where = f"under parent {parent_uuid}" if parent_uuid else "(root)"
+    logger.info(f"Creating DependencyTrack project {name!r} {where}")
+    body: dict[str, Any] = {"name": name}
+    if parent_uuid:
+        body["parent"] = {"uuid": parent_uuid}
+    response = requests.put(
+        f"{dt_url.rstrip('/')}/api/v1/project",
+        json=body,
+        headers={
+            "X-Api-Key": api_key,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+_missing_dt_hint = " — run `pia create-dt-projects` to provision it first"
+
+
 def resolve_dt_child_uuid(
     dt_url: str,
     parent_name: str,
     project_name: str,
     api_key: str,
     root_cache: dict[str, dict[str, Any]] | None = None,
+    create: bool = False,
 ) -> str:
     """Resolve the UUID of child ``project_name`` under root ``parent_name``.
 
     ``root_cache`` (optional) memoises root-project lookups by name so a sync that
     reuses the same DT root across many mappings issues one request per root.
 
-    The projects are only resolved, never created: a root or child that is missing
-    (or ambiguous, i.e. matched more than once) is an error.
+    When ``create`` is set (as ``pia create-dt-projects`` does), a missing root or
+    child project is created rather than raising. ``pia sync`` resolves with
+    ``create=False``, so a missing project is an error there. An *ambiguous* match
+    (more than one) is always an error, even with ``create``.
     """
+    # Resolve (or, with create, provision) the root project, caching it so other
+    # mappings that reuse this root neither re-query nor re-create it. A missing
+    # match is only tolerated when ``create`` is set; ambiguity (>1) is always an
+    # error.
     parent = root_cache.get(parent_name) if root_cache is not None else None
     if parent is None:
         roots = _dt_search_root_projects(dt_url, parent_name, api_key)
-        if len(roots) != 1:
+        if len(roots) != 1 and not (create and not roots):
+            hint = _missing_dt_hint if not roots and not create else ""
             raise click.ClickException(
                 f"Expected exactly one root DependencyTrack project named "
-                f"{parent_name!r}, found {len(roots)}"
+                f"{parent_name!r}, found {len(roots)}{hint}"
             )
-        parent = roots[0]
+        parent = roots[0] if roots else _dt_create_project(dt_url, parent_name, api_key)
         parent.setdefault("children", [])
         if root_cache is not None:
             root_cache[parent_name] = parent
 
+    # Resolve (or provision) the child under the resolved root.
     children = [c for c in parent["children"] if c.get("name") == project_name]
-    if len(children) != 1:
+    if len(children) != 1 and not (create and not children):
+        hint = _missing_dt_hint if not children and not create else ""
         raise click.ClickException(
             f"Expected exactly one child named {project_name!r} under "
-            f"{parent_name!r}, found {len(children)}"
+            f"{parent_name!r}, found {len(children)}{hint}"
         )
-    return children[0]["uuid"]
+    if children:
+        return children[0]["uuid"]
+
+    child = _dt_create_project(
+        dt_url, project_name, api_key, parent_uuid=parent["uuid"]
+    )
+    # Keep the cache consistent for other mappings that reuse this root.
+    parent["children"].append({"name": project_name, "uuid": child["uuid"]})
+    return child["uuid"]
+
+
+def ensure_dt_projects(
+    pf: ProjectsFile, dt_url: str, dt_api_key: str
+) -> list[tuple[str, str]]:
+    """Create any missing DependencyTrack projects for the file's DT mappings.
+
+    For every ``(parent, project)`` mapping in the curated file, ensure the root
+    and child project exist on DependencyTrack, creating whichever are missing.
+    This is the provisioning step behind ``pia create-dt-projects``: it touches
+    only DependencyTrack (no PIA database, no GitHub) and is idempotent — an
+    existing project is resolved, not recreated. Requires a DT API key with
+    PORTFOLIO_MANAGEMENT permission. Returns the ``(parent, project)`` pairs it
+    ensured, for reporting.
+    """
+    root_cache: dict[str, dict[str, Any]] = {}
+    ensured: list[tuple[str, str]] = []
+    for project in pf.projects:
+        for dt in project.dependency_track:
+            resolve_dt_child_uuid(
+                dt_url, dt.parent, dt.project, dt_api_key, root_cache, create=True
+            )
+            ensured.append((dt.parent, dt.project))
+    return ensured
 
 
 # --------------------------------------------------------------------------- #
@@ -274,7 +341,7 @@ def build_desired(
     Performs the external lookups (GitHub owner ids, DependencyTrack child UUIDs).
     ``dt_url`` and ``dt_api_key`` are required (the CLI validates their presence).
     DependencyTrack projects are only *resolved* here, never created: a missing one
-    raises.
+    raises, directing the operator to run ``pia create-dt-projects`` first.
     """
     desired = DB()
     owner_id_cache: dict[str, str] = {}

--- a/pia/sync.py
+++ b/pia/sync.py
@@ -6,7 +6,7 @@ that are no longer in the file.
 
 The file is a list of Eclipse Foundation projects, each with a flat list of workload
 URLs (GitHub repo or Jenkins instance URL — the type is inferred from the host) and a
-list of DependencyTrack (parent, project) mappings. A Jenkins workload is listed as
+list of DependencyTrack (project, product) mappings. A Jenkins workload is listed as
 its instance URL; PIA appends ``/oidc`` to derive the OIDC issuer:
 
     projects:
@@ -15,8 +15,8 @@ its instance URL; PIA appends ``/oidc`` to derive the OIDC issuer:
           - https://github.com/eclipse-foo/repo
           - https://ci.eclipse.org/foo
         dependency_track:
-          - parent: "Eclipse Foo"
-            project: foo-server
+          - project: "Eclipse Foo"
+            product: foo-server
 """
 
 import logging
@@ -50,12 +50,17 @@ logger = logging.getLogger(__name__)
 
 
 class DtProjectSpec(BaseModel):
-    """A DependencyTrack (root project, child project) mapping."""
+    """A DependencyTrack (project, product) mapping.
+
+    ``project`` is the Eclipse Foundation project — a DependencyTrack root project;
+    ``product`` is a product within it — the root's immediate child and the SBOM
+    upload target.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
-    parent: str
     project: str
+    product: str
 
 
 class ProjectSpec(BaseModel):
@@ -126,8 +131,8 @@ def validate_projects_file(pf: ProjectsFile) -> None:
     """Semantic validation beyond structural parsing (no network access).
 
     Enforces: unique project ids; every workload URL is a valid GitHub/Jenkins
-    URL and globally unique; DependencyTrack project names are unique within a
-    project and DependencyTrack (parent, project) mappings are unique across
+    URL and globally unique; DependencyTrack product names are unique within a
+    project and DependencyTrack (project, product) mappings are unique across
     the whole file.
     """
     # Raise on duplicate project IDs
@@ -146,22 +151,22 @@ def validate_projects_file(pf: ProjectsFile) -> None:
                 raise click.ClickException(f"Duplicate resolved workload URL(s): {url}")
             seen_workloads.add(workload)
 
-        # Raise on global duplicate DependencyTrack project names
-        seen_dt_names: set[str] = set()
+        # Raise on global duplicate DependencyTrack product names
+        seen_dt_products: set[str] = set()
         for dt in project.dependency_track:
-            if dt.project in seen_dt_names:
+            if dt.product in seen_dt_products:
                 raise click.ClickException(
-                    f"Duplicate DependencyTrack project name(s) in {project.id!r}: "
-                    f"{dt.project}"
+                    f"Duplicate DependencyTrack product name(s) in {project.id!r}: "
+                    f"{dt.product}"
                 )
-            seen_dt_names.add(dt.project)
+            seen_dt_products.add(dt.product)
 
-            # Raise on global duplicate DependencyTrack parent/project pairs
-            pair = (dt.parent, dt.project)
+            # Raise on global duplicate DependencyTrack project/product pairs
+            pair = (dt.project, dt.product)
             if pair in seen_dt_pairs:
                 raise click.ClickException(
-                    "Duplicate DependencyTrack (parent, project) mapping(s): "
-                    f"{dt.parent}/{dt.project}"
+                    "Duplicate DependencyTrack (project, product) mapping(s): "
+                    f"{dt.project}/{dt.product}"
                 )
             seen_dt_pairs.add(pair)
 
@@ -250,14 +255,16 @@ def _resolve_one_or_create(
 
 def resolve_dt_child_uuid(
     dt_url: str,
-    parent_name: str,
     project_name: str,
+    product_name: str,
     api_key: str,
     root_cache: dict[str, dict[str, Any]] | None = None,
     create: bool = False,
 ) -> str:
-    """Resolve the UUID of child ``project_name`` under root ``parent_name``.
+    """Resolve the UUID of ``product_name`` under root project ``project_name``.
 
+    ``project_name`` is the Eclipse Foundation project (a DependencyTrack root
+    project); ``product_name`` is the product within it (the root's immediate child).
     ``root_cache`` memoises root-project lookups by name so a sync that reuses the
     same DT root across many mappings issues one request per root; pass ``None``
     for a one-off lookup. When ``create`` is set, a missing root or child project
@@ -266,28 +273,28 @@ def resolve_dt_child_uuid(
     if root_cache is None:
         root_cache = {}
 
-    parent = root_cache.get(parent_name)
-    if parent is None:
-        parents = _dt_search_root_projects(dt_url, parent_name, api_key)
-        parent = _resolve_one_or_create(
-            parents,
-            f"root project named {parent_name!r}",
+    root = root_cache.get(project_name)
+    if root is None:
+        roots = _dt_search_root_projects(dt_url, project_name, api_key)
+        root = _resolve_one_or_create(
+            roots,
+            f"root project named {project_name!r}",
             create,
-            lambda: _dt_create_project(dt_url, parent_name, api_key),
+            lambda: _dt_create_project(dt_url, project_name, api_key),
         )
-        parent.setdefault("children", [])
-        root_cache[parent_name] = parent
+        root.setdefault("children", [])
+        root_cache[project_name] = root
 
-    children = [c for c in parent["children"] if c.get("name") == project_name]
+    children = [c for c in root["children"] if c.get("name") == product_name]
     child = _resolve_one_or_create(
         children,
-        f"child project {project_name!r} under root project {parent_name!r}",
+        f"child project {product_name!r} under root project {project_name!r}",
         create,
-        lambda: _dt_create_project(dt_url, project_name, api_key, parent["uuid"]),
+        lambda: _dt_create_project(dt_url, product_name, api_key, root["uuid"]),
     )
-    if child not in parent["children"]:
+    if child not in root["children"]:
         # Update cache with newly created child
-        parent["children"].append(child)
+        root["children"].append(child)
     return child["uuid"]
 
 
@@ -296,12 +303,12 @@ def ensure_dt_projects(
 ) -> list[tuple[str, str]]:
     """Create any missing DependencyTrack projects for the file's DT mappings.
 
-    For every ``(parent, project)`` mapping in the curated file, ensure the root
+    For every ``(project, product)`` mapping in the curated file, ensure the root
     and child project exist on DependencyTrack, creating whichever are missing.
     This is the provisioning step behind ``pia create-dt-projects``: it touches
     only DependencyTrack (no PIA database, no GitHub) and is idempotent — an
     existing project is resolved, not recreated. Requires a DT API key with
-    PORTFOLIO_MANAGEMENT permission. Returns the ``(parent, project)`` pairs it
+    PORTFOLIO_MANAGEMENT permission. Returns the ``(project, product)`` pairs it
     ensured, for reporting.
     """
     root_cache: dict[str, dict[str, Any]] = {}
@@ -309,9 +316,9 @@ def ensure_dt_projects(
     for project in pf.projects:
         for dt in project.dependency_track:
             resolve_dt_child_uuid(
-                dt_url, dt.parent, dt.project, dt_api_key, root_cache, create=True
+                dt_url, dt.project, dt.product, dt_api_key, root_cache, create=True
             )
-            ensured.append((dt.parent, dt.project))
+            ensured.append((dt.project, dt.product))
     return ensured
 
 
@@ -379,14 +386,14 @@ def build_desired(
         for dt in project.dependency_track:
             child_uuid = resolve_dt_child_uuid(
                 dt_url,
-                dt.parent,
                 dt.project,
+                dt.product,
                 dt_api_key,
                 dt_root_cache,
             )
             dtp = DependencyTrackProject(
                 ef_project_id=project.id,
-                name=dt.project,
+                name=dt.product,
                 parent_uuid=child_uuid,
             )
             desired.dt[dtp.diff_key] = dtp

--- a/pia/sync.py
+++ b/pia/sync.py
@@ -1,0 +1,448 @@
+"""Declarative sync of project authorizations from a curated file into the DB.
+
+Reconciles the whole authorization state against a human-curated file (the single
+source of truth): it creates new entries, updates changed ones, and deletes entries
+that are no longer in the file.
+
+The file is a list of Eclipse Foundation projects, each with a flat list of workload
+URLs (GitHub repo or Jenkins instance URL — the type is inferred from the host) and a
+list of DependencyTrack (parent, project) mappings. A Jenkins workload is listed as
+its instance URL; PIA appends ``/oidc`` to derive the OIDC issuer:
+
+    projects:
+      - id: technology.foo
+        workloads:
+          - https://github.com/eclipse-foo/repo
+          - https://ci.eclipse.org/foo
+        dependency_track:
+          - parent: "Eclipse Foo"
+            project: foo-server
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+import click
+import requests
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .models import (
+    GITHUB_BASE_URL,
+    JENKINS_ISSUER_BASE_URL,
+    JENKINS_OIDC_SUFFIX,
+    DependencyTrackProject,
+    EclipseFoundationProject,
+    GitHubWorkload,
+    JenkinsWorkload,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Curated-file model
+# --------------------------------------------------------------------------- #
+
+
+class DtProjectSpec(BaseModel):
+    """A DependencyTrack (root project, child project) mapping."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    parent: str
+    project: str
+
+
+class ProjectSpec(BaseModel):
+    """One Eclipse Foundation project and everything authorized for it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    workloads: list[str] = Field(default_factory=list)
+    dependency_track: list[DtProjectSpec] = Field(default_factory=list)
+
+
+class ProjectsFile(BaseModel):
+    """Top-level curated file."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    projects: list[ProjectSpec] = Field(default_factory=list)
+
+
+def load_projects_file(path: str) -> ProjectsFile:
+    """Parse and structurally validate the curated file at ``path``."""
+    with open(path) as fh:
+        raw = yaml.safe_load(fh)
+    try:
+        return ProjectsFile.model_validate(raw)
+    except ValidationError as e:
+        raise click.ClickException(f"Invalid projects file {path!r}:\n{e}") from e
+
+
+def classify_workload_url(url: str) -> tuple[str, str, str]:
+    """Classify a workload URL by host.
+
+    Returns ``("github", repo_owner, repo_name)`` for a github.com repo URL or
+    ``("jenkins", issuer, "")`` for a ci.eclipse.org Jenkins instance URL. In the
+    Jenkins case the URL is the *workload* URL (``https://ci.eclipse.org/<name>``)
+    and the returned issuer is that URL with ``/oidc`` appended — the file lists
+    workloads, PIA derives the issuer. Raises ``click.ClickException`` for anything
+    else. No network access.
+    """
+    parsed = urlparse(url)
+    base_url = f"{parsed.scheme}://{parsed.hostname}"
+
+    if base_url == GITHUB_BASE_URL:
+        parts = [seg for seg in parsed.path.split("/") if seg]
+        if len(parts) != 2:
+            raise click.ClickException(
+                f"GitHub URL must be '{GITHUB_BASE_URL}/<owner>/<repo>': {url}"
+            )
+        return ("github", parts[0], parts[1])
+
+    if base_url == JENKINS_ISSUER_BASE_URL:
+        parts = [seg for seg in parsed.path.split("/") if seg]
+        if len(parts) != 1:
+            raise click.ClickException(
+                f"Jenkins URL must be {JENKINS_ISSUER_BASE_URL}/<name>: {url}"
+            )
+        issuer = f"{JENKINS_ISSUER_BASE_URL}/{parts[0]}{JENKINS_OIDC_SUFFIX}"
+        return ("jenkins", issuer, "")
+
+    raise click.ClickException(
+        f"URL must be a {GITHUB_BASE_URL} repo URL or a "
+        f"{JENKINS_ISSUER_BASE_URL} instance URL: {url}"
+    )
+
+
+def validate_projects_file(pf: ProjectsFile) -> None:
+    """Semantic validation beyond structural parsing (no network access).
+
+    Enforces: unique project ids; every workload URL is a valid GitHub/Jenkins
+    URL and globally unique; DependencyTrack project names are unique within a
+    project and DependencyTrack (parent, project) mappings are unique across
+    the whole file.
+    """
+    # Raise on duplicate project IDs
+    ids = [p.id for p in pf.projects]
+    dupes = sorted({i for i in ids if ids.count(i) > 1})
+    if dupes:
+        raise click.ClickException(f"Duplicate project id(s): {', '.join(dupes)}")
+
+    seen_workloads: set[tuple[str, str, str]] = set()
+    seen_dt_pairs: set[tuple[str, str]] = set()
+    for project in pf.projects:
+        # Raise on invalid or duplicate **resolved** workloads URLs
+        for url in project.workloads:
+            workload = classify_workload_url(url)
+            if workload in seen_workloads:
+                raise click.ClickException(f"Duplicate resolved workload URL(s): {url}")
+            seen_workloads.add(workload)
+
+        # Raise on global duplicate DependencyTrack project names
+        seen_dt_names: set[str] = set()
+        for dt in project.dependency_track:
+            if dt.project in seen_dt_names:
+                raise click.ClickException(
+                    f"Duplicate DependencyTrack project name(s) in {project.id!r}: "
+                    f"{dt.project}"
+                )
+            seen_dt_names.add(dt.project)
+
+            # Raise on global duplicate DependencyTrack parent/project pairs
+            pair = (dt.parent, dt.project)
+            if pair in seen_dt_pairs:
+                raise click.ClickException(
+                    "Duplicate DependencyTrack (parent, project) mapping(s): "
+                    f"{dt.parent}/{dt.project}"
+                )
+            seen_dt_pairs.add(pair)
+
+
+# --------------------------------------------------------------------------- #
+# Resolution (external lookups)
+# --------------------------------------------------------------------------- #
+
+
+def fetch_github_owner_id(owner: str, token: str | None = None) -> str:
+    """Resolve a GitHub owner login to its numeric id.
+
+    An optional token is sent as a Bearer credential to lift the anonymous rate
+    limit (only public read is needed for ``GET /users/{owner}``).
+    """
+    url = f"https://api.github.com/users/{owner}"
+    logger.info(f"Fetching GitHub owner id from {url}")
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    owner_id = str(response.json()["id"])
+    logger.info(f"GitHub owner {owner!r} has id {owner_id}")
+    return owner_id
+
+
+def _dt_search_root_projects(
+    dt_url: str, name: str, api_key: str
+) -> list[dict[str, Any]]:
+    """Return all root DependencyTrack projects with the given name."""
+    url = f"{dt_url.rstrip('/')}/api/v1/project"
+    logger.info(f"Querying DependencyTrack root projects at {url} for name={name!r}")
+    response = requests.get(
+        url,
+        params={"name": name, "onlyRoot": "true"},
+        headers={"X-Api-Key": api_key, "Accept": "application/json"},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def resolve_dt_child_uuid(
+    dt_url: str,
+    parent_name: str,
+    project_name: str,
+    api_key: str,
+    root_cache: dict[str, dict[str, Any]] | None = None,
+) -> str:
+    """Resolve the UUID of child ``project_name`` under root ``parent_name``.
+
+    ``root_cache`` (optional) memoises root-project lookups by name so a sync that
+    reuses the same DT root across many mappings issues one request per root.
+
+    The projects are only resolved, never created: a root or child that is missing
+    (or ambiguous, i.e. matched more than once) is an error.
+    """
+    parent = root_cache.get(parent_name) if root_cache is not None else None
+    if parent is None:
+        roots = _dt_search_root_projects(dt_url, parent_name, api_key)
+        if len(roots) != 1:
+            raise click.ClickException(
+                f"Expected exactly one root DependencyTrack project named "
+                f"{parent_name!r}, found {len(roots)}"
+            )
+        parent = roots[0]
+        parent.setdefault("children", [])
+        if root_cache is not None:
+            root_cache[parent_name] = parent
+
+    children = [c for c in parent["children"] if c.get("name") == project_name]
+    if len(children) != 1:
+        raise click.ClickException(
+            f"Expected exactly one child named {project_name!r} under "
+            f"{parent_name!r}, found {len(children)}"
+        )
+    return children[0]["uuid"]
+
+
+# --------------------------------------------------------------------------- #
+# DB state
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class DB:
+    """A snapshot of the DB entities, keyed by ``diff_key`` for set-diffing.
+
+    Used for both the desired state (built from the curated file by
+    build_desired) and the current state (loaded from the DB by _load_current).
+    Each entity exposes its own ``diff_key`` (see models.py) — the tuple of all
+    its business columns — so build_desired and _load_current key through the same
+    source of truth and the two sides of the diff can never drift.
+    """
+
+    ef: dict[tuple[str, ...], EclipseFoundationProject] = field(default_factory=dict)
+    github: dict[tuple[str, ...], GitHubWorkload] = field(default_factory=dict)
+    jenkins: dict[tuple[str, ...], JenkinsWorkload] = field(default_factory=dict)
+    dt: dict[tuple[str, ...], DependencyTrackProject] = field(default_factory=dict)
+
+
+def build_desired(
+    pf: ProjectsFile,
+    dt_url: str,
+    dt_api_key: str,
+    github_token: str | None = None,
+) -> DB:
+    """Resolve the curated file into a fully-populated desired state.
+
+    Performs the external lookups (GitHub owner ids, DependencyTrack child UUIDs).
+    ``dt_url`` and ``dt_api_key`` are required (the CLI validates their presence).
+    DependencyTrack projects are only *resolved* here, never created: a missing one
+    raises.
+    """
+    desired = DB()
+    owner_id_cache: dict[str, str] = {}
+    dt_root_cache: dict[str, dict[str, Any]] = {}
+
+    for project in pf.projects:
+        ef = EclipseFoundationProject(id=project.id)
+        desired.ef[ef.diff_key] = ef
+
+        for url in project.workloads:
+            kind, a, b = classify_workload_url(url)
+            if kind == "github":
+                owner, repo = a, b
+                if owner not in owner_id_cache:
+                    owner_id_cache[owner] = fetch_github_owner_id(owner, github_token)
+                gh = GitHubWorkload(
+                    ef_project_id=project.id,
+                    repo_owner=owner,
+                    repo_name=repo,
+                    repo_owner_id=owner_id_cache[owner],
+                )
+                desired.github[gh.diff_key] = gh
+            else:
+                issuer = a
+                jk = JenkinsWorkload(ef_project_id=project.id, issuer=issuer)
+                desired.jenkins[jk.diff_key] = jk
+
+        for dt in project.dependency_track:
+            child_uuid = resolve_dt_child_uuid(
+                dt_url,
+                dt.parent,
+                dt.project,
+                dt_api_key,
+                dt_root_cache,
+            )
+            dtp = DependencyTrackProject(
+                ef_project_id=project.id,
+                name=dt.project,
+                parent_uuid=child_uuid,
+            )
+            desired.dt[dtp.diff_key] = dtp
+
+    return desired
+
+
+# --------------------------------------------------------------------------- #
+# Diff / plan
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Plan:
+    """A reconciliation plan: what to create and delete.
+
+    Modifications are expressed as delete+create for simplicity of this tool
+    and its output. They should be rare anyway.
+
+    Eclipse Foundation project creates/deletes are separate from the
+    creates/deletes lists of child DependencyTrack projects and workloads, to
+    assure foreign-key ordering: child rows reference the parent via
+    ef_project_id, so they must be deleted before their parents, and vice-versa
+    parents must be created before their children.
+    """
+
+    ef_create: list[EclipseFoundationProject] = field(default_factory=list)
+    ef_delete: list[EclipseFoundationProject] = field(default_factory=list)
+    creates: list[Any] = field(default_factory=list)
+    deletes: list[Any] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (self.ef_create or self.ef_delete or self.creates or self.deletes)
+
+
+def _load_current(session: Session) -> DB:
+    return DB(
+        ef={
+            p.diff_key: p
+            for p in session.execute(select(EclipseFoundationProject)).scalars()
+        },
+        github={
+            w.diff_key: w for w in session.execute(select(GitHubWorkload)).scalars()
+        },
+        jenkins={
+            w.diff_key: w for w in session.execute(select(JenkinsWorkload)).scalars()
+        },
+        dt={
+            d.diff_key: d
+            for d in session.execute(select(DependencyTrackProject)).scalars()
+        },
+    )
+
+
+def compute_plan(session: Session, desired: DB) -> Plan:
+    """Diff the desired state against the current DB state. No writes.
+
+    The diff is a set difference over each entity's diff_key: a key only in
+    desired is a create, a key only in current is a delete, and a row whose
+    business columns changed shows up as both (its diff_key differs on each
+    side), i.e. a delete of the old row plus a create of the new one.
+    """
+    current = _load_current(session)
+    plan = Plan()
+
+    # Eclipse Foundation projects go in their own buckets so apply_plan can
+    # honour foreign-key ordering (see Plan). Creates carry the transient desired
+    # row, deletes the attached current one, so apply_plan neither reconstructs
+    # nor re-fetches them.
+    plan.ef_create = [
+        desired.ef[k] for k in sorted(desired.ef.keys() - current.ef.keys())
+    ]
+    plan.ef_delete = [
+        current.ef[k] for k in sorted(current.ef.keys() - desired.ef.keys())
+    ]
+
+    for cur, des in (
+        (current.github, desired.github),
+        (current.jenkins, desired.jenkins),
+        (current.dt, desired.dt),
+    ):
+        plan.creates += [des[k] for k in sorted(des.keys() - cur.keys())]
+        plan.deletes += [cur[k] for k in sorted(cur.keys() - des.keys())]
+
+    return plan
+
+
+def format_plan(plan: Plan) -> str:
+    """Render a plan as a human-readable, reviewable block.
+
+    Shows a create block then a delete block, each rendered from the rows'
+    ``__repr__``. Within a block, Eclipse Foundation projects lead on create and
+    trail on delete, mirroring apply_plan's foreign-key-safe ordering.
+    """
+    if plan.is_empty():
+        return "Plan: no changes — database already matches the file."
+    creates = [*plan.ef_create, *plan.creates]
+    deletes = [*plan.deletes, *plan.ef_delete]
+    out = [f"Plan: {len(creates)} to create, {len(deletes)} to delete"]
+    if creates:
+        out += ["", "Create:", "-" * 7, *(f"+ {obj!r}" for obj in creates)]
+    if deletes:
+        out += ["", "Delete:", "-" * 7, *(f"- {obj!r}" for obj in deletes)]
+    return "\n".join(out)
+
+
+def apply_plan(session: Session, plan: Plan) -> None:
+    """Apply a plan within the given session's transaction (no commit).
+
+    Order matters against the foreign keys: delete child rows, then empty
+    parents; create new parents before their children. Deleting (and flushing)
+    before creating also frees unique keys, so a modification expressed as
+    delete+create of the same business key does not collide with its own old
+    row.
+    """
+    # 1. Delete Workload / DependencyTrack rows before deleting referenced
+    # EF projects
+    for obj in plan.deletes:
+        session.delete(obj)
+    session.flush()
+    # 2. Delete now unreferenced EF projects
+    for obj in plan.ef_delete:
+        session.delete(obj)
+    session.flush()
+    # 3. Create EF projects before any referencing them
+    for obj in plan.ef_create:
+        session.add(obj)
+    session.flush()
+    # 4. Create Workload / DependencyTrack rows with references to just created
+    # EF projects
+    for obj in plan.creates:
+        session.add(obj)
+    session.flush()

--- a/pia/sync.py
+++ b/pia/sync.py
@@ -20,6 +20,7 @@ its instance URL; PIA appends ``/oidc`` to derive the OIDC issuer:
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlparse
@@ -230,6 +231,23 @@ def _dt_create_project(
 _missing_dt_hint = " — run `pia create-dt-projects` to provision it first"
 
 
+def _resolve_one_or_create(
+    matches: list[dict[str, Any]],
+    msg: str,
+    create: bool,
+    factory: Callable[[], dict[str, Any]],
+) -> dict[str, Any]:
+    """Pick the single match, create one, or raise on a missing/ambiguous match."""
+    if len(matches) == 1:
+        return matches[0]
+    if create and not matches:
+        return factory()
+    hint = _missing_dt_hint if not matches and not create else ""
+    raise click.ClickException(
+        f"Expected exactly one DependencyTrack {msg}, found {len(matches)}{hint}"
+    )
+
+
 def resolve_dt_child_uuid(
     dt_url: str,
     parent_name: str,
@@ -240,48 +258,36 @@ def resolve_dt_child_uuid(
 ) -> str:
     """Resolve the UUID of child ``project_name`` under root ``parent_name``.
 
-    ``root_cache`` (optional) memoises root-project lookups by name so a sync that
-    reuses the same DT root across many mappings issues one request per root.
-
-    When ``create`` is set (as ``pia create-dt-projects`` does), a missing root or
-    child project is created rather than raising. ``pia sync`` resolves with
-    ``create=False``, so a missing project is an error there. An *ambiguous* match
-    (more than one) is always an error, even with ``create``.
+    ``root_cache`` memoises root-project lookups by name so a sync that reuses the
+    same DT root across many mappings issues one request per root; pass ``None``
+    for a one-off lookup. When ``create`` is set, a missing root or child project
+    is created rather than raising; an *ambiguous* match is always an error.
     """
-    # Resolve (or, with create, provision) the root project, caching it so other
-    # mappings that reuse this root neither re-query nor re-create it. A missing
-    # match is only tolerated when ``create`` is set; ambiguity (>1) is always an
-    # error.
-    parent = root_cache.get(parent_name) if root_cache is not None else None
+    if root_cache is None:
+        root_cache = {}
+
+    parent = root_cache.get(parent_name)
     if parent is None:
-        roots = _dt_search_root_projects(dt_url, parent_name, api_key)
-        if len(roots) != 1 and not (create and not roots):
-            hint = _missing_dt_hint if not roots and not create else ""
-            raise click.ClickException(
-                f"Expected exactly one root DependencyTrack project named "
-                f"{parent_name!r}, found {len(roots)}{hint}"
-            )
-        parent = roots[0] if roots else _dt_create_project(dt_url, parent_name, api_key)
-        parent.setdefault("children", [])
-        if root_cache is not None:
-            root_cache[parent_name] = parent
-
-    # Resolve (or provision) the child under the resolved root.
-    children = [c for c in parent["children"] if c.get("name") == project_name]
-    if len(children) != 1 and not (create and not children):
-        hint = _missing_dt_hint if not children and not create else ""
-        raise click.ClickException(
-            f"Expected exactly one child named {project_name!r} under "
-            f"{parent_name!r}, found {len(children)}{hint}"
+        parents = _dt_search_root_projects(dt_url, parent_name, api_key)
+        parent = _resolve_one_or_create(
+            parents,
+            f"root project named {parent_name!r}",
+            create,
+            lambda: _dt_create_project(dt_url, parent_name, api_key),
         )
-    if children:
-        return children[0]["uuid"]
+        parent.setdefault("children", [])
+        root_cache[parent_name] = parent
 
-    child = _dt_create_project(
-        dt_url, project_name, api_key, parent_uuid=parent["uuid"]
+    children = [c for c in parent["children"] if c.get("name") == project_name]
+    child = _resolve_one_or_create(
+        children,
+        f"child project {project_name!r} under root project {parent_name!r}",
+        create,
+        lambda: _dt_create_project(dt_url, project_name, api_key, parent["uuid"]),
     )
-    # Keep the cache consistent for other mappings that reuse this root.
-    parent["children"].append({"name": project_name, "uuid": child["uuid"]})
+    if child not in parent["children"]:
+        # Update cache with newly created child
+        parent["children"].append(child)
     return child["uuid"]
 
 

--- a/pia/sync.py
+++ b/pia/sync.py
@@ -43,7 +43,6 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
-
 # --------------------------------------------------------------------------- #
 # Curated-file model
 # --------------------------------------------------------------------------- #
@@ -170,6 +169,8 @@ def validate_projects_file(pf: ProjectsFile) -> None:
 # Resolution (external lookups)
 # --------------------------------------------------------------------------- #
 
+JSON_TYPE = "application/json"
+
 
 def fetch_github_owner_id(owner: str, token: str | None = None) -> str:
     """Resolve a GitHub owner login to its numeric id.
@@ -198,7 +199,7 @@ def _dt_search_root_projects(
     response = requests.get(
         url,
         params={"name": name, "onlyRoot": "true"},
-        headers={"X-Api-Key": api_key, "Accept": "application/json"},
+        headers={"X-Api-Key": api_key, "Accept": JSON_TYPE},
     )
     response.raise_for_status()
     return response.json()
@@ -218,8 +219,8 @@ def _dt_create_project(
         json=body,
         headers={
             "X-Api-Key": api_key,
-            "Accept": "application/json",
-            "Content-Type": "application/json",
+            "Accept": JSON_TYPE,
+            "Content-Type": JSON_TYPE,
         },
     )
     response.raise_for_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "psycopg2-binary>=2.9.0",
     "alembic>=1.15.0",
+    "click>=8.1.0",
+    "pyyaml>=6.0",
 ]
+
+[project.scripts]
+pia = "pia.cli:cli"
 
 [dependency-groups]
 dev = [
@@ -28,6 +33,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "mypy>=1.19.1",
     "types-requests>=2.32.0",
+    "types-PyYAML>=6.0",
 ]
 [tool.ruff]
 extend-exclude = ["alembic/*"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Pytest configuration and shared fixtures."""
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -22,6 +22,16 @@ def engine():
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+
+    # SQLite disables foreign-key enforcement per-connection by default; turn it
+    # on so tests exercise the same referential integrity Postgres enforces in
+    # production (e.g. that apply_plan deletes children before their project).
+    @event.listens_for(engine, "connect")
+    def _enable_sqlite_fk(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
     Base.metadata.create_all(engine)
     yield engine
     engine.dispose()
@@ -44,10 +54,18 @@ def session(session_factory):
 @pytest.fixture
 def seed_db(session):
     """Populate DB with two projects, two workloads, and two DT projects."""
+    # Flush the parent projects before their children: the models carry no
+    # relationship(), so SQLAlchemy cannot infer the insert order needed to
+    # satisfy the foreign keys (now enforced under SQLite too).
     session.add_all(
         [
             EclipseFoundationProject(id="eclipse-test"),
             EclipseFoundationProject(id="eclipse-other"),
+        ]
+    )
+    session.flush()
+    session.add_all(
+        [
             GitHubWorkload(
                 ef_project_id="eclipse-test",
                 repo_owner="eclipse-test",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,631 @@
+"""Tests for the declarative `pia sync` command and reconcile logic."""
+
+import textwrap
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from pia import cli as cli_module
+from pia import sync as sync_module
+from pia.models import (
+    DependencyTrackProject,
+    EclipseFoundationProject,
+    GitHubWorkload,
+    JenkinsWorkload,
+)
+from pia.sync import (
+    DB,
+    apply_plan,
+    classify_workload_url,
+    compute_plan,
+    load_projects_file,
+    validate_projects_file,
+)
+
+
+def _write(tmp_path, text: str) -> str:
+    p = tmp_path / "projects.yaml"
+    p.write_text(textwrap.dedent(text))
+    return str(p)
+
+
+def _resp(json_data):
+    from unittest.mock import MagicMock
+
+    r = MagicMock()
+    r.json.return_value = json_data
+    r.raise_for_status.return_value = None
+    return r
+
+
+# --------------------------------------------------------------------------- #
+# File model + validation
+# --------------------------------------------------------------------------- #
+
+
+def test_classify_workload_url():
+    assert classify_workload_url("https://github.com/owner/repo") == (
+        "github",
+        "owner",
+        "repo",
+    )
+    # A Jenkins workload is listed as its instance URL; the issuer is derived by
+    # appending /oidc.
+    assert classify_workload_url("https://ci.eclipse.org/foo") == (
+        "jenkins",
+        "https://ci.eclipse.org/foo/oidc",
+        "",
+    )
+
+    with pytest.raises(click.ClickException, match="GitHub URL"):
+        classify_workload_url("https://github.com/only-owner")
+
+    with pytest.raises(click.ClickException, match="Jenkins URL"):
+        classify_workload_url("https://ci.eclipse.org")
+
+    with pytest.raises(click.ClickException, match="Jenkins URL"):
+        classify_workload_url("https://ci.eclipse.org/foo/oidc")
+
+    with pytest.raises(click.ClickException, match="URL must be a"):
+        classify_workload_url("https://evil.example/owner/repo")
+
+
+def test_reject_empty_file(tmp_path):
+    # A truncated/blank file parses to nothing; it must not validate as "0
+    # projects" and go on to delete every authorization.
+    with pytest.raises(click.ClickException, match="Invalid projects file"):
+        load_projects_file(_write(tmp_path, ""))
+
+
+def test_load_and_validate_ok(tmp_path):
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            workloads:
+              - https://github.com/eclipse-foo/repo
+              - https://ci.eclipse.org/foo
+            dependency_track:
+              - parent: "Eclipse Foo"
+                project: foo-server
+        """,
+    )
+    pf = load_projects_file(f)
+    validate_projects_file(pf)  # no raise
+    assert [p.id for p in pf.projects] == ["eclipse-foo"]
+
+
+def test_validate_allow_empty_projects_list(tmp_path):
+    pf = load_projects_file(
+        _write(
+            tmp_path,
+            """
+            projects: []
+            """,
+        )
+    )
+    validate_projects_file(pf)
+    assert not pf.projects
+
+
+def test_validate_rejects_duplicate_project_id(tmp_path):
+    pf = load_projects_file(
+        _write(
+            tmp_path,
+            """
+            projects:
+              - id: dup
+              - id: dup
+            """,
+        )
+    )
+    with pytest.raises(click.ClickException, match="Duplicate project id"):
+        validate_projects_file(pf)
+
+
+def test_validate_rejects_duplicate_workload_url(tmp_path):
+    pf = load_projects_file(
+        _write(
+            tmp_path,
+            """
+            projects:
+              - id: a
+                workloads: ["https://github.com/o/r"]
+              - id: b
+                workloads: ["https://github.com/o/r"]
+            """,
+        )
+    )
+    with pytest.raises(click.ClickException, match="Duplicate resolved workload"):
+        validate_projects_file(pf)
+
+
+def test_validate_rejects_colliding_jenkins_issuers(tmp_path):
+    # Two distinct URL strings (trailing-slash variant) derive the same issuer, so
+    # the raw-string dedup misses them; the issuer-level check must catch it.
+    pf = load_projects_file(
+        _write(
+            tmp_path,
+            """
+            projects:
+              - id: a
+                workloads:
+                  - https://ci.eclipse.org/foo
+                  - https://ci.eclipse.org/foo/
+            """,
+        )
+    )
+    with pytest.raises(click.ClickException, match="Duplicate resolved workload"):
+        validate_projects_file(pf)
+
+
+def test_build_desired_derives_jenkins_issuer():
+    # A Jenkins workload listed by instance URL is stored with the /oidc issuer the
+    # OIDC verification path matches against.
+    pf = ProjectsFile(
+        projects=[
+            ProjectSpec(id="eclipse-foo", workloads=["https://ci.eclipse.org/foo"])
+        ]
+    )
+    desired = sync_module.build_desired(
+        pf, dt_url="https://dt.example", dt_api_key="k", github_token=None
+    )
+    assert [jk.issuer for jk in desired.jenkins.values()] == [
+        "https://ci.eclipse.org/foo/oidc"
+    ]
+
+
+def test_validate_rejects_cross_project_dt_mapping(tmp_path):
+    # The DB uniqueness on DependencyTrackProject is (name, parent_uuid) with no
+    # ef_project_id, so the same (parent, project) target under two EF projects
+    # would collide on apply. Validation must reject it up front.
+    pf = load_projects_file(
+        _write(
+            tmp_path,
+            """
+            projects:
+              - id: a
+                dependency_track:
+                  - parent: "Eclipse Foo"
+                    project: shared
+              - id: b
+                dependency_track:
+                  - parent: "Eclipse Foo"
+                    project: shared
+            """,
+        )
+    )
+    with pytest.raises(click.ClickException, match="Duplicate DependencyTrack"):
+        validate_projects_file(pf)
+
+
+def test_validate_allows_same_dt_name_under_different_parents(tmp_path):
+    # Same child name but distinct parents resolves to distinct (name, parent_uuid)
+    # pairs, so it must not be rejected as a cross-project collision.
+    pf = load_projects_file(
+        _write(
+            tmp_path,
+            """
+            projects:
+              - id: a
+                dependency_track:
+                  - parent: "Eclipse Foo"
+                    project: shared
+              - id: b
+                dependency_track:
+                  - parent: "Eclipse Bar"
+                    project: shared
+            """,
+        )
+    )
+    validate_projects_file(pf)  # no raise
+
+
+def test_validate_rejects_unknown_field(tmp_path):
+    pf_path = _write(
+        tmp_path,
+        """
+        projects:
+          - id: a
+            bogus: true
+        """,
+    )
+    with pytest.raises(click.ClickException, match="Invalid projects file"):
+        load_projects_file(pf_path)
+
+
+# --------------------------------------------------------------------------- #
+# Diff (compute_plan)
+# --------------------------------------------------------------------------- #
+
+
+def _db(*, ef=(), github=(), jenkins=(), dt=()) -> DB:
+    """Build a DB snapshot from object lists, keyed via diff_key like production."""
+    return DB(
+        ef={o.diff_key: o for o in ef},
+        github={o.diff_key: o for o in github},
+        jenkins={o.diff_key: o for o in jenkins},
+        dt={o.diff_key: o for o in dt},
+    )
+
+
+def test_compute_plan_creates_on_empty_db(session):
+    desired = _db(
+        ef=[EclipseFoundationProject(id="eclipse-foo")],
+        github=[
+            GitHubWorkload(
+                ef_project_id="eclipse-foo",
+                repo_owner="eclipse-foo",
+                repo_name="repo",
+                repo_owner_id="7",
+            )
+        ],
+        jenkins=[
+            JenkinsWorkload(
+                ef_project_id="eclipse-foo", issuer="https://ci.eclipse.org/foo/oidc"
+            )
+        ],
+        dt=[
+            DependencyTrackProject(
+                ef_project_id="eclipse-foo", name="prod", parent_uuid="uuidX"
+            )
+        ],
+    )
+    plan = compute_plan(session, desired)
+    assert [p.id for p in plan.ef_create] == ["eclipse-foo"]
+    assert len(plan.creates) == 3
+    assert not plan.deletes
+    assert not plan.ef_delete
+
+
+def test_compute_plan_noop_when_matching(seed_db):
+    session = seed_db
+    desired = _desired_matching_seed()
+    plan = compute_plan(session, desired)
+    assert plan.is_empty()
+
+
+def test_compute_plan_update_is_delete_plus_create(seed_db):
+    session = seed_db
+    desired = _desired_matching_seed()
+    # Change the resolved owner id for the existing GitHub workload (seed has
+    # exactly one), so its diff key differs from the current row's.
+    gh = GitHubWorkload(
+        ef_project_id="eclipse-test",
+        repo_owner="eclipse-test",
+        repo_name="repo",
+        repo_owner_id="99",
+    )
+    desired.github = {gh.diff_key: gh}
+    plan = compute_plan(session, desired)
+    # A modification is expressed as delete of the old row + create of the new.
+    assert not plan.ef_create and not plan.ef_delete
+    assert len(plan.deletes) == 1 and len(plan.creates) == 1
+    assert isinstance(plan.deletes[0], GitHubWorkload)
+    assert plan.deletes[0].repo_owner_id == "42"
+    assert isinstance(plan.creates[0], GitHubWorkload)
+    assert plan.creates[0].repo_owner_id == "99"
+
+
+def test_compute_plan_deletes_removed(seed_db):
+    session = seed_db
+    # Keep only eclipse-test's GitHub workload + DT project; drop everything else.
+    desired = _db(
+        ef=[EclipseFoundationProject(id="eclipse-test")],
+        github=[
+            GitHubWorkload(
+                ef_project_id="eclipse-test",
+                repo_owner="eclipse-test",
+                repo_name="repo",
+                repo_owner_id="42",
+            )
+        ],
+        dt=[
+            DependencyTrackProject(
+                ef_project_id="eclipse-test", name="test-product", parent_uuid="uuid-1"
+            )
+        ],
+    )
+    plan = compute_plan(session, desired)
+    assert [p.id for p in plan.ef_delete] == ["eclipse-other"]
+    deleted_kinds = sorted(type(o).__name__ for o in plan.deletes)
+    assert deleted_kinds == ["DependencyTrackProject", "JenkinsWorkload"]
+    assert not plan.creates
+
+
+# --------------------------------------------------------------------------- #
+# Apply
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_creates_then_idempotent(session):
+    desired = _db(
+        ef=[EclipseFoundationProject(id="p")],
+        github=[
+            GitHubWorkload(
+                ef_project_id="p", repo_owner="o", repo_name="r", repo_owner_id="1"
+            )
+        ],
+    )
+    apply_plan(session, compute_plan(session, desired))
+    session.commit()
+
+    assert session.query(GitHubWorkload).count() == 1
+    assert session.query(EclipseFoundationProject).count() == 1
+    # Re-running against the now-populated DB is a no-op.
+    assert compute_plan(session, desired).is_empty()
+
+
+def test_apply_update_replaces_row(seed_db):
+    # An update is delete+create of the same business key; applying it must not
+    # collide with the old row's unique key and must leave exactly one new row.
+    session = seed_db
+    desired = _desired_matching_seed()
+    gh = GitHubWorkload(
+        ef_project_id="eclipse-test",
+        repo_owner="eclipse-test",
+        repo_name="repo",
+        repo_owner_id="99",
+    )
+    desired.github = {gh.diff_key: gh}
+    apply_plan(session, compute_plan(session, desired))
+    session.commit()
+
+    rows = session.query(GitHubWorkload).all()
+    assert len(rows) == 1
+    assert rows[0].repo_owner_id == "99"
+
+
+def test_apply_deletes_children_before_project(seed_db):
+    session = seed_db
+    # Reconcile to a file that no longer contains eclipse-other at all.
+    desired = _db(
+        ef=[EclipseFoundationProject(id="eclipse-test")],
+        github=[
+            GitHubWorkload(
+                ef_project_id="eclipse-test",
+                repo_owner="eclipse-test",
+                repo_name="repo",
+                repo_owner_id="42",
+            )
+        ],
+        dt=[
+            DependencyTrackProject(
+                ef_project_id="eclipse-test", name="test-product", parent_uuid="uuid-1"
+            )
+        ],
+    )
+    apply_plan(session, compute_plan(session, desired))
+    session.commit()
+
+    assert session.query(JenkinsWorkload).count() == 0
+    assert (
+        session.query(EclipseFoundationProject).filter_by(id="eclipse-other").count()
+        == 0
+    )
+    assert session.query(DependencyTrackProject).count() == 1
+    assert session.query(GitHubWorkload).count() == 1
+
+
+def _desired_matching_seed() -> DB:
+    """A DB that exactly mirrors the `seed_db` fixture contents."""
+    return _db(
+        ef=[
+            EclipseFoundationProject(id="eclipse-test"),
+            EclipseFoundationProject(id="eclipse-other"),
+        ],
+        github=[
+            GitHubWorkload(
+                ef_project_id="eclipse-test",
+                repo_owner="eclipse-test",
+                repo_name="repo",
+                repo_owner_id="42",
+            )
+        ],
+        jenkins=[
+            JenkinsWorkload(
+                ef_project_id="eclipse-other",
+                issuer="https://ci.eclipse.org/eclipse-other/oidc",
+            )
+        ],
+        dt=[
+            DependencyTrackProject(
+                ef_project_id="eclipse-test", name="test-product", parent_uuid="uuid-1"
+            ),
+            DependencyTrackProject(
+                ef_project_id="eclipse-other",
+                name="other-product",
+                parent_uuid="uuid-2",
+            ),
+        ],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CLI-level
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def patch_cli(session_factory, monkeypatch):
+    """Point the CLI at the in-memory DB and stub the network resolvers."""
+    monkeypatch.setenv("PIA_DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("PIA_DEPENDENCY_TRACK_API_KEY", "test-key")
+    monkeypatch.setattr(cli_module, "_make_session", session_factory)
+    monkeypatch.setattr(
+        sync_module, "fetch_github_owner_id", lambda owner, token=None: "42"
+    )
+    monkeypatch.setattr(
+        sync_module,
+        "resolve_dt_child_uuid",
+        lambda dt_url, parent, project, api_key, root_cache=None: "uuid-1",
+    )
+
+
+def test_sync_check_is_offline(runner, tmp_path, monkeypatch):
+    # No DB URL and no network are needed for --check.
+    monkeypatch.delenv("PIA_DATABASE_URL", raising=False)
+
+    def no_network(*a, **kw):
+        raise AssertionError("network must not be touched for --check")
+
+    monkeypatch.setattr(sync_module.requests, "get", no_network)
+
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            workloads: ["https://github.com/eclipse-foo/repo"]
+        """,
+    )
+    result = runner.invoke(cli_module.cli, ["sync", f, "--check"])
+    assert result.exit_code == 0, result.output
+    assert "valid" in result.output
+
+
+def test_sync_requires_dt_config_even_without_dt_entries(
+    runner, tmp_path, session_factory, patch_cli
+):
+    # DT config is required unconditionally, even for a file with no
+    # dependency_track entries. Here --dt-url is omitted, so sync must refuse.
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            workloads: ["https://github.com/eclipse-foo/repo"]
+        """,
+    )
+    result = runner.invoke(cli_module.cli, ["sync", f])
+    assert result.exit_code != 0
+    assert "--dt-url and PIA_DEPENDENCY_TRACK_API_KEY are required" in result.output
+
+
+def test_sync_dry_run_writes_nothing(runner, tmp_path, session_factory, patch_cli):
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            workloads: ["https://github.com/eclipse-foo/repo"]
+            dependency_track:
+              - parent: "Eclipse Foo"
+                project: foo-server
+        """,
+    )
+    result = runner.invoke(
+        cli_module.cli, ["sync", f, "--dt-url", "https://dt", "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Plan:" in result.output
+    with session_factory() as s:
+        assert s.query(GitHubWorkload).count() == 0
+        assert s.query(EclipseFoundationProject).count() == 0
+
+
+def test_sync_fails_on_missing_dt_project(
+    runner, tmp_path, session_factory, monkeypatch
+):
+    # sync resolves DependencyTrack projects read-only, so a missing one is a hard
+    # error rather than something it provisions.
+    # (patch_cli is intentionally not used: it stubs resolve_dt_child_uuid, which is
+    # exactly the resolution path under test.)
+    monkeypatch.setenv("PIA_DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("PIA_DEPENDENCY_TRACK_API_KEY", "test-key")
+    monkeypatch.setattr(cli_module, "_make_session", session_factory)
+    monkeypatch.setattr(
+        sync_module, "fetch_github_owner_id", lambda owner, token=None: "42"
+    )
+    monkeypatch.setattr(sync_module.requests, "get", lambda *a, **k: _resp([]))
+
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            dependency_track:
+              - parent: "Eclipse Foo"
+                project: foo-server
+        """,
+    )
+    result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
+    assert result.exit_code != 0
+    assert "Expected exactly one root" in result.output
+
+
+def test_sync_apply_creates_rows(runner, tmp_path, session_factory, patch_cli):
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            workloads: ["https://github.com/eclipse-foo/repo"]
+            dependency_track:
+              - parent: "Eclipse Foo"
+                project: foo-server
+        """,
+    )
+    result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
+    assert result.exit_code == 0, result.output
+    with session_factory() as s:
+        assert s.query(GitHubWorkload).count() == 1
+        assert s.query(DependencyTrackProject).count() == 1
+        assert s.query(EclipseFoundationProject).count() == 1
+
+
+def test_sync_updates_and_deletions_require_allow_flag(
+    runner, tmp_path, session_factory, patch_cli
+):
+    # Seed rows that the file below will no longer contain.
+    with session_factory() as s:
+        s.add_all(
+            [
+                EclipseFoundationProject(id="eclipse-foo"),
+                EclipseFoundationProject(id="eclipse-stale"),
+                JenkinsWorkload(
+                    ef_project_id="eclipse-stale",
+                    issuer="https://ci.eclipse.org/stale/oidc",
+                ),
+            ]
+        )
+        s.commit()
+
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            workloads: ["https://github.com/eclipse-foo/repo"]
+        """,
+    )
+
+    # Without the allow flag, a plan with deletions is refused and nothing changes.
+    result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
+    assert result.exit_code != 0
+    assert "updates and/or deletions" in result.output
+    with session_factory() as s:
+        assert s.query(JenkinsWorkload).count() == 1
+        assert (
+            s.query(EclipseFoundationProject).filter_by(id="eclipse-stale").count() == 1
+        )
+
+    # With the allow flag, the stale workload and now-empty project are removed.
+    result = runner.invoke(
+        cli_module.cli,
+        ["sync", f, "--dt-url", "https://dt", "--allow-db-updates-and-deletions"],
+    )
+    assert result.exit_code == 0, result.output
+    with session_factory() as s:
+        assert s.query(JenkinsWorkload).count() == 0
+        assert (
+            s.query(EclipseFoundationProject).filter_by(id="eclipse-stale").count() == 0
+        )
+        assert s.query(GitHubWorkload).count() == 1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -77,10 +77,11 @@ def test_classify_workload_url():
 
 
 def test_reject_empty_file(tmp_path):
+    f = _write(tmp_path, "")
     # A truncated/blank file parses to nothing; it must not validate as "0
     # projects" and go on to delete every authorization.
     with pytest.raises(click.ClickException, match="Invalid projects file"):
-        load_projects_file(_write(tmp_path, ""))
+        load_projects_file(f)
 
 
 def test_load_and_validate_ok(tmp_path):
@@ -654,7 +655,7 @@ def test_resolve_dt_missing_without_create_raises(monkeypatch):
     with pytest.raises(
         click.ClickException, match="Expected exactly one DependencyTrack root project"
     ):
-        resolve_dt_child_uuid("http://dt", "Root", "Child", "key", create=False)
+        resolve_dt_child_uuid("https://dt", "Root", "Child", "key", create=False)
 
 
 def test_resolve_dt_creates_missing_root_and_child(monkeypatch):
@@ -670,7 +671,7 @@ def test_resolve_dt_creates_missing_root_and_child(monkeypatch):
     monkeypatch.setattr(sync_module.requests, "get", fake_get)
     monkeypatch.setattr(sync_module.requests, "put", fake_put)
 
-    uuid = resolve_dt_child_uuid("http://dt", "Root", "Child", "key", {}, create=True)
+    uuid = resolve_dt_child_uuid("https://dt", "Root", "Child", "key", {}, create=True)
 
     assert uuid == "uuid-Child"
     # Root created first (no parent), then child under the new root.
@@ -692,7 +693,7 @@ def test_resolve_dt_creates_only_missing_child(monkeypatch):
 
     monkeypatch.setattr(sync_module.requests, "put", fake_put)
 
-    uuid = resolve_dt_child_uuid("http://dt", "Root", "Child", "key", {}, create=True)
+    uuid = resolve_dt_child_uuid("https://dt", "Root", "Child", "key", {}, create=True)
 
     assert uuid == "child-uuid"
     assert len(puts) == 1
@@ -713,7 +714,7 @@ def test_resolve_dt_ambiguous_root_errors_even_with_create(monkeypatch):
     with pytest.raises(
         click.ClickException, match="Expected exactly one DependencyTrack root project"
     ):
-        resolve_dt_child_uuid("http://dt", "Root", "Child", "key", create=True)
+        resolve_dt_child_uuid("https://dt", "Root", "Child", "key", create=True)
 
 
 def test_ensure_dt_projects_creates_missing(monkeypatch):
@@ -734,7 +735,7 @@ def test_ensure_dt_projects_creates_missing(monkeypatch):
             )
         ]
     )
-    ensured = ensure_dt_projects(pf, "http://dt", "key")
+    ensured = ensure_dt_projects(pf, "https://dt", "key")
 
     assert ensured == [("Root", "Child")]
     # Root created first (no parent), then child under the new root.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,10 +16,15 @@ from pia.models import (
 )
 from pia.sync import (
     DB,
+    DtProjectSpec,
+    ProjectsFile,
+    ProjectSpec,
     apply_plan,
     classify_workload_url,
     compute_plan,
+    ensure_dt_projects,
     load_projects_file,
+    resolve_dt_child_uuid,
     validate_projects_file,
 )
 
@@ -465,7 +470,9 @@ def patch_cli(session_factory, monkeypatch):
     monkeypatch.setattr(
         sync_module,
         "resolve_dt_child_uuid",
-        lambda dt_url, parent, project, api_key, root_cache=None: "uuid-1",
+        lambda dt_url, parent, project, api_key, root_cache=None, create=False: (
+            "uuid-1"
+        ),
     )
 
 
@@ -534,8 +541,8 @@ def test_sync_dry_run_writes_nothing(runner, tmp_path, session_factory, patch_cl
 def test_sync_fails_on_missing_dt_project(
     runner, tmp_path, session_factory, monkeypatch
 ):
-    # sync resolves DependencyTrack projects read-only, so a missing one is a hard
-    # error rather than something it provisions.
+    # sync never creates DependencyTrack projects: a missing one is a hard error
+    # that points the operator at `pia create-dt-projects`, and no PUT is issued.
     # (patch_cli is intentionally not used: it stubs resolve_dt_child_uuid, which is
     # exactly the resolution path under test.)
     monkeypatch.setenv("PIA_DATABASE_URL", "sqlite:///:memory:")
@@ -545,6 +552,11 @@ def test_sync_fails_on_missing_dt_project(
         sync_module, "fetch_github_owner_id", lambda owner, token=None: "42"
     )
     monkeypatch.setattr(sync_module.requests, "get", lambda *a, **k: _resp([]))
+
+    def fail_put(*a, **k):
+        raise AssertionError("sync must not create DependencyTrack projects")
+
+    monkeypatch.setattr(sync_module.requests, "put", fail_put)
 
     f = _write(
         tmp_path,
@@ -559,6 +571,7 @@ def test_sync_fails_on_missing_dt_project(
     result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
     assert result.exit_code != 0
     assert "Expected exactly one root" in result.output
+    assert "create-dt-projects" in result.output
 
 
 def test_sync_apply_creates_rows(runner, tmp_path, session_factory, patch_cli):
@@ -629,3 +642,150 @@ def test_sync_updates_and_deletions_require_allow_flag(
             s.query(EclipseFoundationProject).filter_by(id="eclipse-stale").count() == 0
         )
         assert s.query(GitHubWorkload).count() == 1
+
+
+# --------------------------------------------------------------------------- #
+# DependencyTrack project creation (resolve_dt_child_uuid / pia create-dt-projects)
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_dt_missing_without_create_raises(monkeypatch):
+    monkeypatch.setattr(sync_module.requests, "get", lambda *a, **k: _resp([]))
+    with pytest.raises(click.ClickException, match="Expected exactly one root"):
+        resolve_dt_child_uuid("http://dt", "Root", "Child", "key", create=False)
+
+
+def test_resolve_dt_creates_missing_root_and_child(monkeypatch):
+    puts = []
+
+    def fake_get(*a, **k):
+        return _resp([])  # no root exists
+
+    def fake_put(url, json=None, **k):
+        puts.append((json["name"], json.get("parent")))
+        return _resp({"uuid": f"uuid-{json['name']}", "name": json["name"]})
+
+    monkeypatch.setattr(sync_module.requests, "get", fake_get)
+    monkeypatch.setattr(sync_module.requests, "put", fake_put)
+
+    uuid = resolve_dt_child_uuid("http://dt", "Root", "Child", "key", {}, create=True)
+
+    assert uuid == "uuid-Child"
+    # Root created first (no parent), then child under the new root.
+    assert puts[0] == ("Root", None)
+    assert puts[1] == ("Child", {"uuid": "uuid-Root"})
+
+
+def test_resolve_dt_creates_only_missing_child(monkeypatch):
+    puts = []
+    monkeypatch.setattr(
+        sync_module.requests,
+        "get",
+        lambda *a, **k: _resp([{"name": "Root", "uuid": "root-uuid", "children": []}]),
+    )
+
+    def fake_put(url, json=None, **k):
+        puts.append(json)
+        return _resp({"uuid": "child-uuid", "name": json["name"]})
+
+    monkeypatch.setattr(sync_module.requests, "put", fake_put)
+
+    uuid = resolve_dt_child_uuid("http://dt", "Root", "Child", "key", {}, create=True)
+
+    assert uuid == "child-uuid"
+    assert len(puts) == 1
+    assert puts[0]["parent"] == {"uuid": "root-uuid"}
+
+
+def test_resolve_dt_ambiguous_root_errors_even_with_create(monkeypatch):
+    monkeypatch.setattr(
+        sync_module.requests,
+        "get",
+        lambda *a, **k: _resp(
+            [
+                {"name": "Root", "uuid": "1", "children": []},
+                {"name": "Root", "uuid": "2", "children": []},
+            ]
+        ),
+    )
+    with pytest.raises(click.ClickException, match="Expected exactly one root"):
+        resolve_dt_child_uuid("http://dt", "Root", "Child", "key", create=True)
+
+
+def test_ensure_dt_projects_creates_missing(monkeypatch):
+    puts = []
+    monkeypatch.setattr(sync_module.requests, "get", lambda *a, **k: _resp([]))
+
+    def fake_put(url, json=None, **k):
+        puts.append(json["name"])
+        return _resp({"uuid": f"uuid-{json['name']}", "name": json["name"]})
+
+    monkeypatch.setattr(sync_module.requests, "put", fake_put)
+
+    pf = ProjectsFile(
+        projects=[
+            ProjectSpec(
+                id="p",
+                dependency_track=[DtProjectSpec(parent="Root", project="Child")],
+            )
+        ]
+    )
+    ensured = ensure_dt_projects(pf, "http://dt", "key")
+
+    assert ensured == [("Root", "Child")]
+    # Root created first (no parent), then child under the new root.
+    assert puts == ["Root", "Child"]
+
+
+def test_create_dt_projects_command_creates_missing(runner, tmp_path, monkeypatch):
+    monkeypatch.setenv("PIA_DEPENDENCY_TRACK_API_KEY", "test-key")
+    monkeypatch.setattr(sync_module.requests, "get", lambda *a, **k: _resp([]))
+    puts = []
+
+    def fake_put(url, json=None, **k):
+        puts.append(json["name"])
+        return _resp({"uuid": f"uuid-{json['name']}", "name": json["name"]})
+
+    monkeypatch.setattr(sync_module.requests, "put", fake_put)
+
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            dependency_track:
+              - parent: "Eclipse Foo"
+                project: foo-server
+        """,
+    )
+    result = runner.invoke(
+        cli_module.cli, ["create-dt-projects", f, "--dt-url", "https://dt"]
+    )
+    assert result.exit_code == 0, result.output
+    assert puts == ["Eclipse Foo", "foo-server"]
+    assert "Ensured 1" in result.output
+
+
+def test_create_dt_projects_command_requires_dt_config(runner, tmp_path, monkeypatch):
+    monkeypatch.setenv("PIA_DEPENDENCY_TRACK_API_KEY", "test-key")
+
+    def no_network(*a, **k):
+        raise AssertionError("must refuse before any network access")
+
+    monkeypatch.setattr(sync_module.requests, "get", no_network)
+    monkeypatch.setattr(sync_module.requests, "put", no_network)
+
+    f = _write(
+        tmp_path,
+        """
+        projects:
+          - id: eclipse-foo
+            dependency_track:
+              - parent: "Eclipse Foo"
+                project: foo-server
+        """,
+    )
+    # --dt-url omitted -> refuse before touching DependencyTrack.
+    result = runner.invoke(cli_module.cli, ["create-dt-projects", f])
+    assert result.exit_code != 0
+    assert "--dt-url and PIA_DEPENDENCY_TRACK_API_KEY are required" in result.output

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -570,7 +570,7 @@ def test_sync_fails_on_missing_dt_project(
     )
     result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
     assert result.exit_code != 0
-    assert "Expected exactly one root" in result.output
+    assert "Expected exactly one DependencyTrack root project" in result.output
     assert "create-dt-projects" in result.output
 
 
@@ -651,7 +651,9 @@ def test_sync_updates_and_deletions_require_allow_flag(
 
 def test_resolve_dt_missing_without_create_raises(monkeypatch):
     monkeypatch.setattr(sync_module.requests, "get", lambda *a, **k: _resp([]))
-    with pytest.raises(click.ClickException, match="Expected exactly one root"):
+    with pytest.raises(
+        click.ClickException, match="Expected exactly one DependencyTrack root project"
+    ):
         resolve_dt_child_uuid("http://dt", "Root", "Child", "key", create=False)
 
 
@@ -708,7 +710,9 @@ def test_resolve_dt_ambiguous_root_errors_even_with_create(monkeypatch):
             ]
         ),
     )
-    with pytest.raises(click.ClickException, match="Expected exactly one root"):
+    with pytest.raises(
+        click.ClickException, match="Expected exactly one DependencyTrack root project"
+    ):
         resolve_dt_child_uuid("http://dt", "Root", "Child", "key", create=True)
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -94,8 +94,8 @@ def test_load_and_validate_ok(tmp_path):
               - https://github.com/eclipse-foo/repo
               - https://ci.eclipse.org/foo
             dependency_track:
-              - parent: "Eclipse Foo"
-                project: foo-server
+              - project: "Eclipse Foo"
+                product: foo-server
         """,
     )
     pf = load_projects_file(f)
@@ -185,7 +185,7 @@ def test_build_desired_derives_jenkins_issuer():
 
 def test_validate_rejects_cross_project_dt_mapping(tmp_path):
     # The DB uniqueness on DependencyTrackProject is (name, parent_uuid) with no
-    # ef_project_id, so the same (parent, project) target under two EF projects
+    # ef_project_id, so the same (project, product) target under two EF projects
     # would collide on apply. Validation must reject it up front.
     pf = load_projects_file(
         _write(
@@ -194,12 +194,12 @@ def test_validate_rejects_cross_project_dt_mapping(tmp_path):
             projects:
               - id: a
                 dependency_track:
-                  - parent: "Eclipse Foo"
-                    project: shared
+                  - project: "Eclipse Foo"
+                    product: shared
               - id: b
                 dependency_track:
-                  - parent: "Eclipse Foo"
-                    project: shared
+                  - project: "Eclipse Foo"
+                    product: shared
             """,
         )
     )
@@ -207,9 +207,9 @@ def test_validate_rejects_cross_project_dt_mapping(tmp_path):
         validate_projects_file(pf)
 
 
-def test_validate_allows_same_dt_name_under_different_parents(tmp_path):
-    # Same child name but distinct parents resolves to distinct (name, parent_uuid)
-    # pairs, so it must not be rejected as a cross-project collision.
+def test_validate_allows_same_dt_product_under_different_projects(tmp_path):
+    # Same product name but distinct projects resolves to distinct (name,
+    # parent_uuid) pairs, so it must not be rejected as a cross-project collision.
     pf = load_projects_file(
         _write(
             tmp_path,
@@ -217,12 +217,12 @@ def test_validate_allows_same_dt_name_under_different_parents(tmp_path):
             projects:
               - id: a
                 dependency_track:
-                  - parent: "Eclipse Foo"
-                    project: shared
+                  - project: "Eclipse Foo"
+                    product: shared
               - id: b
                 dependency_track:
-                  - parent: "Eclipse Bar"
-                    project: shared
+                  - project: "Eclipse Bar"
+                    product: shared
             """,
         )
     )
@@ -471,7 +471,7 @@ def patch_cli(session_factory, monkeypatch):
     monkeypatch.setattr(
         sync_module,
         "resolve_dt_child_uuid",
-        lambda dt_url, parent, project, api_key, root_cache=None, create=False: (
+        lambda dt_url, project, product, api_key, root_cache=None, create=False: (
             "uuid-1"
         ),
     )
@@ -525,8 +525,8 @@ def test_sync_dry_run_writes_nothing(runner, tmp_path, session_factory, patch_cl
           - id: eclipse-foo
             workloads: ["https://github.com/eclipse-foo/repo"]
             dependency_track:
-              - parent: "Eclipse Foo"
-                project: foo-server
+              - project: "Eclipse Foo"
+                product: foo-server
         """,
     )
     result = runner.invoke(
@@ -565,8 +565,8 @@ def test_sync_fails_on_missing_dt_project(
         projects:
           - id: eclipse-foo
             dependency_track:
-              - parent: "Eclipse Foo"
-                project: foo-server
+              - project: "Eclipse Foo"
+                product: foo-server
         """,
     )
     result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
@@ -583,8 +583,8 @@ def test_sync_apply_creates_rows(runner, tmp_path, session_factory, patch_cli):
           - id: eclipse-foo
             workloads: ["https://github.com/eclipse-foo/repo"]
             dependency_track:
-              - parent: "Eclipse Foo"
-                project: foo-server
+              - project: "Eclipse Foo"
+                product: foo-server
         """,
     )
     result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
@@ -731,7 +731,7 @@ def test_ensure_dt_projects_creates_missing(monkeypatch):
         projects=[
             ProjectSpec(
                 id="p",
-                dependency_track=[DtProjectSpec(parent="Root", project="Child")],
+                dependency_track=[DtProjectSpec(project="Root", product="Child")],
             )
         ]
     )
@@ -759,8 +759,8 @@ def test_create_dt_projects_command_creates_missing(runner, tmp_path, monkeypatc
         projects:
           - id: eclipse-foo
             dependency_track:
-              - parent: "Eclipse Foo"
-                project: foo-server
+              - project: "Eclipse Foo"
+                product: foo-server
         """,
     )
     result = runner.invoke(
@@ -786,8 +786,8 @@ def test_create_dt_projects_command_requires_dt_config(runner, tmp_path, monkeyp
         projects:
           - id: eclipse-foo
             dependency_track:
-              - parent: "Eclipse Foo"
-                project: foo-server
+              - project: "Eclipse Foo"
+                product: foo-server
         """,
     )
     # --dt-url omitted -> refuse before touching DependencyTrack.

--- a/uv.lock
+++ b/uv.lock
@@ -549,11 +549,13 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "click" },
     { name = "fastapi" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlalchemy" },
     { name = "uvicorn" },
@@ -566,17 +568,20 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
     { name = "types-requests" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.15.0" },
+    { name = "click", specifier = ">=8.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.38.0" },
@@ -589,6 +594,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.9" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "types-requests", specifier = ">=2.32.0" },
 ]
 
@@ -785,6 +791,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -874,6 +916,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Registering workloads and DependencyTrack projects one command invocation at a time leaves the database as the only record of who is authorized: it cannot be reviewed, there is no way to revoke an entry, and re-running a registration duplicates rows (hence https://github.com/eclipse-csi/pia/pull/69).

This PR makes a curated file the source of truth instead, and adds a command to reconcile the whole authorization state against it.

`pia sync <file>` loads the file, resolves the external data it references (GitHub owner ids, DependencyTrack child UUIDs), diffs the result against the database, prints the plan, and applies it — creating and deleting rows (updates are modeled as deletes and creates for simplicitity), so the database matches the file. 

As syncing resolves against the actual DependencyTrack projects the connected instance, the referenced projects must exist at sync time. To ensure this use `pia create-dt-projects`.

Note: In our deployment `pia sync` needs to run within the cluster for DB access, whereas `pia create-dt-projects` can run outside of the cluster.

See commit messages and docs for details about the commands.

 


