### PR TITLE
Add DependencyTrack to docker-compose for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,29 @@ prior to syncing.
 
 See [CLI section of the design doc](docs/DESIGN.md#55-cli-tool) or run with
 `--help` for more info.
+
+#### Local Testing
+
+The `docker compose` stack includes a local DependencyTrack API server, so you
+can exercise `pia sync` end to end.
+
+1. **Start the stack.** This brings up Postgres, DependencyTrack, and the app
+   (which applies migrations on startup):
+   ```shell
+   docker compose up -d
+   ```
+
+2. **Provision a DependencyTrack token.** DependencyTrack takes 1-2 minutes to
+   become ready on first start; this command waits for it and creates an API
+   token:
+   ```shell
+   uv run python scripts/dt_bootstrap.py
+   ```
+   The DependencyTrack UI/API is at http://localhost:8080 (admin login is
+   printed by the command).
+
+3. **Run a sync** against the local database and DependencyTrack using the
+   command printed by `scripts/dt_bootstrap.py`.
+
+   Drop `--dry-run` to apply, then re-run to see an empty (idempotent) plan.
+   Edit `projects.local.yaml` and re-run to see updates and deletions in the plan.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - PIA_DEPENDENCY_TRACK_API_KEY=${PIA_DEPENDENCY_TRACK_API_KEY:-test-api-key}
       - PIA_DATABASE_URL=postgresql://pia:pia@postgres:5432/pia
       - PIA_EXPECTED_AUDIENCE=${PIA_EXPECTED_AUDIENCE:-pia.eclipse.org}
-      - PIA_DEPENDENCY_TRACK_URL=${PIA_DEPENDENCY_TRACK_URL:-https://sbom.eclipse.org/api/v1/bom}
+      - PIA_DEPENDENCY_TRACK_URL=${PIA_DEPENDENCY_TRACK_URL:-http://dtrack:8080/api/v1/bom}
     volumes:
       - ./pia:/app/pia:ro
       - ./pyproject.toml:/app/pyproject.toml:ro
@@ -20,6 +20,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      dtrack:
+        condition: service_started
     # Dev-only convenience: apply migrations, then start the app with --reload
     # for hot-reloading of the mounted code. In production migrations are run as
     # a separate step (a Helm pre-upgrade hook job), not on app startup, so the
@@ -42,5 +44,24 @@ services:
       timeout: 5s
       retries: 5
 
+  # Local DependencyTrack API server for trying the app and `pia sync` end to
+  # end. Uses the bundled embedded database (data persisted in the dtrack-data
+  # volume) — no external Postgres wiring needed for local use. It takes 1-2
+  # minutes to become ready on first start; `scripts/dt_bootstrap` waits for
+  # it, then provisions an API token. The web UI (frontend) is not included;
+  # the REST API is served on port 8080.
+  dtrack:
+    image: dependencytrack/apiserver:4.12.7
+    container_name: pia-dtrack
+    ports:
+      - "8080:8080"
+    environment:
+      # DependencyTrack hard-requires a 4GB heap and refuses to start with less.
+      # Ensure Docker has at least ~4-5GB of memory available.
+      - EXTRA_JAVA_OPTIONS=-Xmx4g
+    volumes:
+      - dtrack-data:/data
+
 volumes:
   pia-postgres-data:
+  dtrack-data:

--- a/projects.local.yaml
+++ b/projects.local.yaml
@@ -1,10 +1,12 @@
 # Example curated file for trying `pia sync` against the local docker-compose
 # stack (see README "Local Testing").
 projects:
-  - id: eclipse-csi
+  - id: technology.csi
     workloads:
       - https://github.com/eclipse-csi/pia
+      - https://github.com/eclipse-csi/otterdog
     dependency_track:
       - project: "Eclipse CSI"
         product: pia
+      - project: "Eclipse CSI"
         product: otterdog

--- a/projects.local.yaml
+++ b/projects.local.yaml
@@ -1,0 +1,10 @@
+# Example curated file for trying `pia sync` against the local docker-compose
+# stack (see README "Local Testing").
+projects:
+  - id: eclipse-csi
+    workloads:
+      - https://github.com/eclipse-csi/pia
+    dependency_track:
+      - project: "Eclipse CSI"
+        product: pia
+        product: otterdog

--- a/scripts/dt_bootstrap.py
+++ b/scripts/dt_bootstrap.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Bootstrap the local DependencyTrack for development.
+
+Waits for the DependencyTrack API (from docker-compose) to come up, changes the
+default admin password on first run, provisions a team with the permissions the
+PIA app and `pia sync` need and generates and prints an API token.
+
+Usage:
+    uv run python scripts/dt_bootstrap.py
+
+Environment overrides: DT_URL (default http://localhost:8080),
+DT_ADMIN_PASSWORD (default set below).
+"""
+
+import os
+import sys
+import time
+
+import requests
+
+DT_URL = os.environ.get("DT_URL", "http://localhost:8080").rstrip("/")
+ADMIN_USER = "admin"
+DEFAULT_PASSWORD = "admin"
+NEW_PASSWORD = os.environ.get("DT_ADMIN_PASSWORD", "PiaLocal123!")
+TEAM_NAME = "pia-local"
+# Permissions needed by `pia sync` (VIEW_PORTFOLIO to query projects) and by the
+# PIA app when uploading SBOMs against this local instance.
+TEAM_PERMISSIONS = [
+    "VIEW_PORTFOLIO",
+    "PORTFOLIO_MANAGEMENT",
+    "PROJECT_CREATION_UPLOAD",
+    "BOM_UPLOAD",
+]
+
+
+def log(msg: str) -> None:
+    print(f"[dt-bootstrap] {msg}", flush=True)
+
+
+def wait_for_api(timeout: int = 240) -> None:
+    log(f"Waiting for DependencyTrack at {DT_URL} (up to {timeout}s)...")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            r = requests.get(f"{DT_URL}/api/version", timeout=5)
+            if r.ok:
+                log(f"DependencyTrack {r.json().get('version', '?')} is up.")
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(5)
+    sys.exit(f"DependencyTrack did not become ready within {timeout}s.")
+
+
+def login(password: str) -> str | None:
+    """Return a JWT for admin with the given password, or None if it fails."""
+    r = requests.post(
+        f"{DT_URL}/api/v1/user/login",
+        data={"username": ADMIN_USER, "password": password},
+        timeout=15,
+    )
+    if r.status_code == 200:
+        return r.text.strip().strip('"')
+    return None
+
+
+def ensure_admin_password() -> str:
+    """Log in as admin, forcing the first-run password change if needed."""
+    token = login(NEW_PASSWORD)
+    if token:
+        log("Logged in as admin (password already set).")
+        return token
+
+    log("First run: changing the default admin password.")
+    r = requests.post(
+        f"{DT_URL}/api/v1/user/forceChangePassword",
+        data={
+            "username": ADMIN_USER,
+            "password": DEFAULT_PASSWORD,
+            "newPassword": NEW_PASSWORD,
+            "confirmPassword": NEW_PASSWORD,
+        },
+        timeout=15,
+    )
+    if r.status_code not in (200, 204):
+        sys.exit(
+            "Could not change the admin password "
+            f"(HTTP {r.status_code}: {r.text!r}). If you set a custom password "
+            "before, pass it via DT_ADMIN_PASSWORD."
+        )
+    token = login(NEW_PASSWORD)
+    if not token:
+        sys.exit("Password changed but login still failed.")
+    return token
+
+
+def ensure_team(auth: dict[str, str]) -> str:
+    """Return the UUID of the TEAM_NAME team, creating it if necessary."""
+    r = requests.get(f"{DT_URL}/api/v1/team", headers=auth, timeout=15)
+    r.raise_for_status()
+    for team in r.json():
+        if team.get("name") == TEAM_NAME:
+            return team["uuid"]
+    r = requests.put(
+        f"{DT_URL}/api/v1/team", headers=auth, json={"name": TEAM_NAME}, timeout=15
+    )
+    r.raise_for_status()
+    log(f"Created team {TEAM_NAME!r}.")
+    return r.json()["uuid"]
+
+
+def ensure_permissions(auth: dict[str, str], team_uuid: str) -> None:
+    for perm in TEAM_PERMISSIONS:
+        r = requests.post(
+            f"{DT_URL}/api/v1/permission/{perm}/team/{team_uuid}",
+            headers=auth,
+            timeout=15,
+        )
+        # 200 = added, 304 = already present.
+        if r.status_code not in (200, 304):
+            log(f"Warning: could not grant {perm} (HTTP {r.status_code}).")
+    log(f"Granted permissions: {', '.join(TEAM_PERMISSIONS)}.")
+
+
+def generate_api_key(auth: dict[str, str], team_uuid: str) -> str:
+    r = requests.put(f"{DT_URL}/api/v1/team/{team_uuid}/key", headers=auth, timeout=15)
+    r.raise_for_status()
+    body = r.json()
+    # DependencyTrack returns {"key": "..."} (older) or {"publicId":..,"key":..}.
+    return body["key"] if isinstance(body, dict) else str(body)
+
+
+def main() -> None:
+    wait_for_api()
+    jwt = ensure_admin_password()
+    auth = {"Authorization": f"Bearer {jwt}"}
+
+    team_uuid = ensure_team(auth)
+    ensure_permissions(auth, team_uuid)
+    key = generate_api_key(auth, team_uuid)
+
+    print("\n" + "=" * 70)
+    print("DependencyTrack is ready.")
+    print(f"  API:   {DT_URL}")
+    print(f"  Admin: {ADMIN_USER} / {NEW_PASSWORD}")
+    print(f"  Token: {key}")
+    print("=" * 70)
+    print("\nTry the sync CLI locally:\n")
+    print("  export PIA_DATABASE_URL=postgresql://pia:pia@localhost:5432/pia")
+    print(f"  export PIA_DEPENDENCY_TRACK_API_KEY={key}")
+    print(f"  uv run pia sync projects.local.yaml --dt-url {DT_URL} --dry-run\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dt_bootstrap.py
+++ b/scripts/dt_bootstrap.py
@@ -8,20 +8,23 @@ PIA app and `pia sync` need and generates and prints an API token.
 Usage:
     uv run python scripts/dt_bootstrap.py
 
-Environment overrides: DT_URL (default http://localhost:8080),
-DT_ADMIN_PASSWORD (default set below).
+Targets the local docker-compose DependencyTrack only; the URL and admin
+credentials are hard-coded for that disposable instance.
 """
 
-import os
 import sys
 import time
 
 import requests
 
-DT_URL = os.environ.get("DT_URL", "http://localhost:8080").rstrip("/")
+DT_URL = "http://localhost:8080"
 ADMIN_USER = "admin"
 DEFAULT_PASSWORD = "admin"
-NEW_PASSWORD = os.environ.get("DT_ADMIN_PASSWORD", "PiaLocal123!")
+
+# Local-dev only: DependencyTrack from docker-compose is disposable and never
+# exposed. Hard-coded (not env-configurable) to keep the local scope unambiguous;
+# stable so re-runs can log back in.
+NEW_PASSWORD = "PiaLocal123!"
 TEAM_NAME = "pia-local"
 # Permissions needed by `pia sync` (VIEW_PORTFOLIO to query projects) and by the
 # PIA app when uploading SBOMs against this local instance.
@@ -85,8 +88,9 @@ def ensure_admin_password() -> str:
     if r.status_code not in (200, 204):
         sys.exit(
             "Could not change the admin password "
-            f"(HTTP {r.status_code}: {r.text!r}). If you set a custom password "
-            "before, pass it via DT_ADMIN_PASSWORD."
+            f"(HTTP {r.status_code}: {r.text!r}). If the local DependencyTrack "
+            "already has a non-default password, reset it with "
+            "`docker compose down -v` and re-run."
         )
     token = login(NEW_PASSWORD)
     if not token:

--- a/scripts/dt_bootstrap.py
+++ b/scripts/dt_bootstrap.py
@@ -24,7 +24,7 @@ DEFAULT_PASSWORD = "admin"
 # Local-dev only: DependencyTrack from docker-compose is disposable and never
 # exposed. Hard-coded (not env-configurable) to keep the local scope unambiguous;
 # stable so re-runs can log back in.
-NEW_PASSWORD = "PiaLocal123!"
+NEW_PASSWORD = "PiaLocal123!"  # NOSONAR
 TEAM_NAME = "pia-local"
 # Permissions needed by `pia sync` (VIEW_PORTFOLIO to query projects) and by the
 # PIA app when uploading SBOMs against this local instance.


### PR DESCRIPTION
- Add a dependencytrack/apiserver service (embedded H2, 4GB heap) and volume
- Add scripts/dt_bootstrap.py: waits for DT, sets the admin
  password, provisions a team/permissions/API token, and prints the
  `pia sync` command including token and dt url for testing.
- Add projects.local.yaml sample and a README walkthrough