### PR TITLE
Set collection logic on created DependencyTrack projects

### DIFF
--- a/pia/sync.py
+++ b/pia/sync.py
@@ -214,12 +214,19 @@ def _dt_search_root_projects(
 def _dt_create_project(
     dt_url: str, name: str, api_key: str, parent_uuid: str | None = None
 ) -> dict[str, Any]:
-    """Create a DependencyTrack project (root if ``parent_uuid`` is None)."""
+    """Create a DependencyTrack project (root if ``parent_uuid`` is None).
+
+    Root projects aggregate their direct children; non-root aggregate direct
+    children marked as latest.
+    """
     where = f"under parent {parent_uuid}" if parent_uuid else "(root)"
     logger.info(f"Creating DependencyTrack project {name!r} {where}")
     body: dict[str, Any] = {"name": name}
     if parent_uuid:
         body["parent"] = {"uuid": parent_uuid}
+        body["collectionLogic"] = "AGGREGATE_LATEST_VERSION_CHILDREN"
+    else:
+        body["collectionLogic"] = "AGGREGATE_DIRECT_CHILDREN"
     response = requests.put(
         f"{dt_url.rstrip('/')}/api/v1/project",
         json=body,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -665,7 +665,7 @@ def test_resolve_dt_creates_missing_root_and_child(monkeypatch):
         return _resp([])  # no root exists
 
     def fake_put(url, json=None, **k):
-        puts.append((json["name"], json.get("parent")))
+        puts.append(json)
         return _resp({"uuid": f"uuid-{json['name']}", "name": json["name"]})
 
     monkeypatch.setattr(sync_module.requests, "get", fake_get)
@@ -675,8 +675,12 @@ def test_resolve_dt_creates_missing_root_and_child(monkeypatch):
 
     assert uuid == "uuid-Child"
     # Root created first (no parent), then child under the new root.
-    assert puts[0] == ("Root", None)
-    assert puts[1] == ("Child", {"uuid": "uuid-Root"})
+    assert puts[0]["name"] == "Root"
+    assert "parent" not in puts[0]
+    assert puts[0]["collectionLogic"] == "AGGREGATE_DIRECT_CHILDREN"
+    assert puts[1]["name"] == "Child"
+    assert puts[1]["parent"] == {"uuid": "uuid-Root"}
+    assert puts[1]["collectionLogic"] == "AGGREGATE_LATEST_VERSION_CHILDREN"
 
 
 def test_resolve_dt_creates_only_missing_child(monkeypatch):
@@ -698,6 +702,7 @@ def test_resolve_dt_creates_only_missing_child(monkeypatch):
     assert uuid == "child-uuid"
     assert len(puts) == 1
     assert puts[0]["parent"] == {"uuid": "root-uuid"}
+    assert puts[0]["collectionLogic"] == "AGGREGATE_LATEST_VERSION_CHILDREN"
 
 
 def test_resolve_dt_ambiguous_root_errors_even_with_create(monkeypatch):


### PR DESCRIPTION
Root projects aggregate their direct children; non-root projects aggregate direct children marked as latest.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>i

Fixes #74 