### PR TITLE
Map one DependencyTrack root project per Eclipse project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [Design Document](docs/DESIGN.md) for details.
 
 PIA uses [uv](https://docs.astral.sh/uv/) for Python project management.
 
-1. **Clone and changew into repository:**
+1. **Clone and change into repository:**
    ```bash
    git clone https://github.com/eclipse-csi/pia.git && cd pia
    ```

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -384,8 +384,8 @@ using the `PIA_DATABASE_URL` environment variable, e.g.
 
 Reconciles the whole authorization state to match a curated projects file. The
 file lists Eclipse Foundation projects, each with a flat list of workload URLs
-(GitHub repo or Jenkins instance URL — classified by host) and a list of
-DependencyTrack `(project, product)` mappings. `sync` resolves the external
+(GitHub repo or Jenkins instance URL — classified by host) and a single
+DependencyTrack project with its products. `sync` resolves the external
 data (GitHub owner ids, DependencyTrack child UUIDs), diffs the desired state
 against the database, prints a plan, and applies it so the database matches the
 file.
@@ -399,16 +399,28 @@ projects:
       - https://github.com/eclipse-foo/repo
       - https://ci.eclipse.org/foo
     dependency_track:
-      - project: "Eclipse Foo"
-        product: foo-server
+      project: "Eclipse Foo"
+      products:
+        - foo-server
+        - foo-cli
 ```
+
+Every DependencyTrack name in the file — projects and products alike — must be
+globally unique, and `sync` rejects a file that repeats one. PIA creates these
+projects without a version, and DependencyTrack refuses a `(name, version)` that
+already exists *regardless of parent*, so two projects each naming a product
+`cli` could never both be provisioned. Global uniqueness also makes the Eclipse
+Foundation project to DependencyTrack project mapping 1:1: the file structure
+gives one DependencyTrack project per Eclipse project, this rule gives one
+Eclipse project per DependencyTrack project.
 
 #### `pia create-dt-projects`
 
-Ensures every `(project, product)` DependencyTrack mapping in the curated file
-exists on DependencyTrack, creating any missing root/child projects. This is a
-provisioning step only — it does **not** touch the PIA database — so run it before
-`pia sync` whenever a file introduces new DependencyTrack targets.
+Ensures the DependencyTrack project and products of every Eclipse Foundation
+project in the curated file exist on DependencyTrack, creating any missing
+root/child projects. This is a provisioning step only — it does **not** touch the
+PIA database — so run it before `pia sync` whenever a file introduces new
+DependencyTrack targets.
 
 ## 6. Security Considerations
 

--- a/pia/cli.py
+++ b/pia/cli.py
@@ -151,10 +151,11 @@ def sync(
 def create_dt_projects(file: str, dt_url: str | None) -> None:
     """Create the DependencyTrack projects referenced by a curated FILE.
 
-    Ensures every (project, product) DependencyTrack mapping in the file exists,
-    creating any missing root/child projects. Provisioning only — it does not touch
-    the PIA database, so run it before `pia sync` whenever a file introduces new
-    DependencyTrack targets. Idempotent: existing projects are left as-is.
+    Ensures the DependencyTrack project and products of every Eclipse Foundation
+    project in the file exist, creating any missing root/child projects.
+    Provisioning only — it does not touch the PIA database, so run it before
+    `pia sync` whenever a file introduces new DependencyTrack targets.
+    Idempotent: existing projects are left as-is.
 
     Requires --dt-url and PIA_DEPENDENCY_TRACK_API_KEY (with PORTFOLIO_MANAGEMENT
     permission to create projects).

--- a/pia/models.py
+++ b/pia/models.py
@@ -175,7 +175,17 @@ class JenkinsWorkload(Workload):
 
 
 class DependencyTrackProject(Base):
-    """DependencyTrack target for SBOM uploads."""
+    """DependencyTrack target for SBOM uploads.
+
+    ``name`` is the DependencyTrack name shared by two projects: the
+    version-less "product aggregation project", whose UUID is ``parent_uuid``,
+    and the per-version "product project" DependencyTrack auto-creates on each
+    upload. It is matched against ``product_name`` from the PIA upload::
+
+        <DependencyTrack project>   root, one per Eclipse Foundation project
+        └── <name>                  product aggregation — parent_uuid points here
+            └── <name> <version>    auto-created per upload, one per version
+    """
 
     __tablename__ = "dependency_track_projects"
 
@@ -189,16 +199,32 @@ class DependencyTrackProject(Base):
     name: Mapped[str] = mapped_column(String)
     parent_uuid: Mapped[str] = mapped_column(String)
 
+    # UNIQUE("name", "parent_uuid"): A DependencyTrack target belongs to exactly
+    # one EF project, so an upload authorized for one can never reach
+    # another's. Caveat: This holds as long as `name` and `parent_uuid` in a
+    # row refer to the same DependencyTrack project. However, an incoherent row
+    # would escape the constraint, since uploads are routed by `parent_uuid`
+    # alone:
+    # ("eclipse.foo", "cli", "UUID-A") and ("eclipse.bar", "cli-other", "UUID-A")
+    # satisfy the constraint, while sending both projects into "UUID-A".
+    # `pia sync` guarantees coherency.
+    #
+    # UNIQUE("ef_project_id", "name"): A `product_name` must resolve to at most
+    # one `name` within the authenticated workload's EF project in
+    # `find_dt_project`. This constraint is a defensive policy, to avoid a 500
+    # on upload due to an unhandled `MultipleResultsFound` from
+    # `scalar_one_or_none`, if the assumption from above does not hold true.
+    #
+    # Neither constraint makes `name` globally unique, so two EF projects can
+    # each claim a product named "cli" here. `validate_projects_file` rejects
+    # that outright — the curated file is the only writer, and DependencyTrack
+    # would refuse the second one at provisioning anyway.
+    #
+    # TODO: Consider replacing both constraints with single-column constraints
+    # on "name" and "parent_uuid" — or on "name" alone, once "parent_uuid" is
+    # dropped with eclipse-csi/pia#79.
     __table_args__ = (
-        # DependencyTrack targets (product name plus uuid) are globally unique
-        # and map to exactly one EF project. Keeping it globally unique stops
-        # two EF projects from pointing at the same DT target, so an upload
-        # authorized for one project can never reach another's DT project.
         UniqueConstraint("name", "parent_uuid"),
-        # DependencyTrack target names (product name) are unique within an EF
-        # project to avoid ambiguity when resolving the target based on the
-        # name in the upload payload. They are not globally unique, to allow
-        # different EF projects to e.g. upload a product named "cli" or "server".
         UniqueConstraint("ef_project_id", "name"),
     )
 

--- a/pia/sync.py
+++ b/pia/sync.py
@@ -6,7 +6,7 @@ that are no longer in the file.
 
 The file is a list of Eclipse Foundation projects, each with a flat list of workload
 URLs (GitHub repo or Jenkins instance URL — the type is inferred from the host) and a
-list of DependencyTrack (project, product) mappings. A Jenkins workload is listed as
+single DependencyTrack project with its products. A Jenkins workload is listed as
 its instance URL; PIA appends ``/oidc`` to derive the OIDC issuer:
 
     projects:
@@ -15,8 +15,10 @@ its instance URL; PIA appends ``/oidc`` to derive the OIDC issuer:
           - https://github.com/eclipse-foo/repo
           - https://ci.eclipse.org/foo
         dependency_track:
-          - project: "Eclipse Foo"
-            product: foo-server
+          project: "Eclipse Foo"
+          products:
+            - foo-server
+            - foo-cli
 """
 
 import logging
@@ -50,17 +52,17 @@ logger = logging.getLogger(__name__)
 
 
 class DtProjectSpec(BaseModel):
-    """A DependencyTrack (project, product) mapping.
+    """The DependencyTrack project and its products.
 
-    ``project`` is the Eclipse Foundation project — a DependencyTrack root project;
-    ``product`` is a product within it — the root's immediate child and the SBOM
-    upload target.
+    ``project`` is a DependencyTrack root project of an Eclipse Foundation
+    project, and it is the parent of all its products; ``products`` are the
+    root's immediate children and the SBOM upload targets.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     project: str
-    product: str
+    products: list[str] = Field(min_length=1)
 
 
 class ProjectSpec(BaseModel):
@@ -70,7 +72,7 @@ class ProjectSpec(BaseModel):
 
     id: str
     workloads: list[str] = Field(default_factory=list)
-    dependency_track: list[DtProjectSpec] = Field(default_factory=list)
+    dependency_track: DtProjectSpec | None = None
 
 
 class ProjectsFile(BaseModel):
@@ -130,10 +132,9 @@ def classify_workload_url(url: str) -> tuple[str, str, str]:
 def validate_projects_file(pf: ProjectsFile) -> None:
     """Semantic validation beyond structural parsing (no network access).
 
-    Enforces: unique project ids; every workload URL is a valid GitHub/Jenkins
-    URL and globally unique; DependencyTrack product names are unique within a
-    project and DependencyTrack (project, product) mappings are unique across
-    the whole file.
+    Enforces: globally unique Eclipse Foundation project ids; globally unique
+    workload URLs that are valid GitHub/Jenkins URLs; and globally unique
+    DependencyTrack names (projects and products alike).
     """
     # Raise on duplicate project IDs
     ids = [p.id for p in pf.projects]
@@ -142,7 +143,7 @@ def validate_projects_file(pf: ProjectsFile) -> None:
         raise click.ClickException(f"Duplicate project id(s): {', '.join(dupes)}")
 
     seen_workloads: set[tuple[str, str, str]] = set()
-    seen_dt_pairs: set[tuple[str, str]] = set()
+    seen_dt_names: set[str] = set()
     for project in pf.projects:
         # Raise on invalid or duplicate **resolved** workloads URLs
         for url in project.workloads:
@@ -151,24 +152,17 @@ def validate_projects_file(pf: ProjectsFile) -> None:
                 raise click.ClickException(f"Duplicate resolved workload URL(s): {url}")
             seen_workloads.add(workload)
 
-        # Raise on global duplicate DependencyTrack product names
-        seen_dt_products: set[str] = set()
-        for dt in project.dependency_track:
-            if dt.product in seen_dt_products:
-                raise click.ClickException(
-                    f"Duplicate DependencyTrack product name(s) in {project.id!r}: "
-                    f"{dt.product}"
-                )
-            seen_dt_products.add(dt.product)
+        dt = project.dependency_track
+        if not dt:
+            continue
 
-            # Raise on global duplicate DependencyTrack project/product pairs
-            pair = (dt.project, dt.product)
-            if pair in seen_dt_pairs:
+        # Raise on any - project or product - DependencyTrack name used twice
+        for name in (dt.project, *dt.products):
+            if name in seen_dt_names:
                 raise click.ClickException(
-                    "Duplicate DependencyTrack (project, product) mapping(s): "
-                    f"{dt.project}/{dt.product}"
+                    f"Duplicate DependencyTrack project name in {project.id!r}: {name}"
                 )
-            seen_dt_pairs.add(pair)
+            seen_dt_names.add(name)
 
 
 # --------------------------------------------------------------------------- #
@@ -236,6 +230,12 @@ def _dt_create_project(
             "Content-Type": JSON_TYPE,
         },
     )
+    if response.status_code == 409:
+        raise click.ClickException(
+            f"DependencyTrack already has a project named {name!r}. "
+            "DependencyTrack projects must be globally unique across all "
+            "hierarchy levels."
+        )
     response.raise_for_status()
     return response.json()
 
@@ -310,7 +310,7 @@ def ensure_dt_projects(
 ) -> list[tuple[str, str]]:
     """Create any missing DependencyTrack projects for the file's DT mappings.
 
-    For every ``(project, product)`` mapping in the curated file, ensure the root
+    For every product of every curated Eclipse Foundation project, ensure the root
     and child project exist on DependencyTrack, creating whichever are missing.
     This is the provisioning step behind ``pia create-dt-projects``: it touches
     only DependencyTrack (no PIA database, no GitHub) and is idempotent — an
@@ -321,11 +321,14 @@ def ensure_dt_projects(
     root_cache: dict[str, dict[str, Any]] = {}
     ensured: list[tuple[str, str]] = []
     for project in pf.projects:
-        for dt in project.dependency_track:
+        dt = project.dependency_track
+        if not dt:
+            continue
+        for product in dt.products:
             resolve_dt_child_uuid(
-                dt_url, dt.project, dt.product, dt_api_key, root_cache, create=True
+                dt_url, dt.project, product, dt_api_key, root_cache, create=True
             )
-            ensured.append((dt.project, dt.product))
+            ensured.append((dt.project, product))
     return ensured
 
 
@@ -390,17 +393,21 @@ def build_desired(
                 jk = JenkinsWorkload(ef_project_id=project.id, issuer=issuer)
                 desired.jenkins[jk.diff_key] = jk
 
-        for dt in project.dependency_track:
+        dt = project.dependency_track
+        if not dt:
+            continue
+
+        for product in dt.products:
             child_uuid = resolve_dt_child_uuid(
                 dt_url,
                 dt.project,
-                dt.product,
+                product,
                 dt_api_key,
                 dt_root_cache,
             )
             dtp = DependencyTrackProject(
                 ef_project_id=project.id,
-                name=dt.product,
+                name=product,
                 parent_uuid=child_uuid,
             )
             desired.dt[dtp.diff_key] = dtp

--- a/projects.local.yaml
+++ b/projects.local.yaml
@@ -6,7 +6,7 @@ projects:
       - https://github.com/eclipse-csi/pia
       - https://github.com/eclipse-csi/otterdog
     dependency_track:
-      - project: "Eclipse CSI"
-        product: pia
-      - project: "Eclipse CSI"
-        product: otterdog
+      project: "Eclipse CSI"
+      products:
+        - pia
+        - otterdog

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -94,8 +94,8 @@ def test_load_and_validate_ok(tmp_path):
               - https://github.com/eclipse-foo/repo
               - https://ci.eclipse.org/foo
             dependency_track:
-              - project: "Eclipse Foo"
-                product: foo-server
+              project: "Eclipse Foo"
+              products: [foo-server]
         """,
     )
     pf = load_projects_file(f)
@@ -183,10 +183,7 @@ def test_build_desired_derives_jenkins_issuer():
     ]
 
 
-def test_validate_rejects_cross_project_dt_mapping(tmp_path):
-    # The DB uniqueness on DependencyTrackProject is (name, parent_uuid) with no
-    # ef_project_id, so the same (project, product) target under two EF projects
-    # would collide on apply. Validation must reject it up front.
+def test_validate_rejects_colliding_dt_projects(tmp_path):
     pf = load_projects_file(
         _write(
             tmp_path,
@@ -194,22 +191,20 @@ def test_validate_rejects_cross_project_dt_mapping(tmp_path):
             projects:
               - id: a
                 dependency_track:
-                  - project: "Eclipse Foo"
-                    product: shared
+                  project: "Eclipse Foo"
+                  products: [server]
               - id: b
                 dependency_track:
-                  - project: "Eclipse Foo"
-                    product: shared
+                  project: "Eclipse Foo"
+                  products: [cli]
             """,
         )
     )
-    with pytest.raises(click.ClickException, match="Duplicate DependencyTrack"):
+    with pytest.raises(click.ClickException, match="Duplicate DependencyTrack project"):
         validate_projects_file(pf)
 
 
-def test_validate_allows_same_dt_product_under_different_projects(tmp_path):
-    # Same product name but distinct projects resolves to distinct (name,
-    # parent_uuid) pairs, so it must not be rejected as a cross-project collision.
+def test_validate_rejects_colliding_dt_products(tmp_path):
     pf = load_projects_file(
         _write(
             tmp_path,
@@ -217,16 +212,72 @@ def test_validate_allows_same_dt_product_under_different_projects(tmp_path):
             projects:
               - id: a
                 dependency_track:
-                  - project: "Eclipse Foo"
-                    product: shared
+                  project: "Eclipse Foo"
+                  products: [shared]
               - id: b
                 dependency_track:
-                  - project: "Eclipse Bar"
-                    product: shared
+                  project: "Eclipse Bar"
+                  products: [shared]
             """,
         )
     )
-    validate_projects_file(pf)  # no raise
+    with pytest.raises(click.ClickException, match="Duplicate DependencyTrack project"):
+        validate_projects_file(pf)
+
+
+def test_validate_rejects_colliding_dt_project_and_product(tmp_path):
+    pf = load_projects_file(
+        _write(
+            tmp_path,
+            """
+            projects:
+              - id: a
+                dependency_track:
+                  project: "Eclipse Foo"
+                  products: [pia]
+              - id: b
+                dependency_track:
+                  project: "pia"
+                  products: [cli]
+            """,
+        )
+    )
+    with pytest.raises(click.ClickException, match="Duplicate DependencyTrack project"):
+        validate_projects_file(pf)
+
+
+def test_validate_rejects_colliding_local_dt_products(tmp_path):
+    pf = load_projects_file(
+        _write(
+            tmp_path,
+            """
+            projects:
+              - id: a
+                dependency_track:
+                  project: "Eclipse Foo"
+                  products: [server, server]
+            """,
+        )
+    )
+    with pytest.raises(
+        click.ClickException, match="Duplicate DependencyTrack project name"
+    ):
+        validate_projects_file(pf)
+
+
+def test_load_rejects_dt_project_without_products(tmp_path):
+    pf_path = _write(
+        tmp_path,
+        """
+        projects:
+          - id: a
+            dependency_track:
+              project: "Eclipse Foo"
+              products: []
+        """,
+    )
+    with pytest.raises(click.ClickException, match="Invalid projects file"):
+        load_projects_file(pf_path)
 
 
 def test_validate_rejects_unknown_field(tmp_path):
@@ -525,8 +576,8 @@ def test_sync_dry_run_writes_nothing(runner, tmp_path, session_factory, patch_cl
           - id: eclipse-foo
             workloads: ["https://github.com/eclipse-foo/repo"]
             dependency_track:
-              - project: "Eclipse Foo"
-                product: foo-server
+              project: "Eclipse Foo"
+              products: [foo-server]
         """,
     )
     result = runner.invoke(
@@ -565,8 +616,8 @@ def test_sync_fails_on_missing_dt_project(
         projects:
           - id: eclipse-foo
             dependency_track:
-              - project: "Eclipse Foo"
-                product: foo-server
+              project: "Eclipse Foo"
+              products: [foo-server]
         """,
     )
     result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
@@ -583,8 +634,8 @@ def test_sync_apply_creates_rows(runner, tmp_path, session_factory, patch_cli):
           - id: eclipse-foo
             workloads: ["https://github.com/eclipse-foo/repo"]
             dependency_track:
-              - project: "Eclipse Foo"
-                product: foo-server
+              project: "Eclipse Foo"
+              products: [foo-server]
         """,
     )
     result = runner.invoke(cli_module.cli, ["sync", f, "--dt-url", "https://dt"])
@@ -736,7 +787,7 @@ def test_ensure_dt_projects_creates_missing(monkeypatch):
         projects=[
             ProjectSpec(
                 id="p",
-                dependency_track=[DtProjectSpec(project="Root", product="Child")],
+                dependency_track=DtProjectSpec(project="Root", products=["Child"]),
             )
         ]
     )
@@ -764,8 +815,8 @@ def test_create_dt_projects_command_creates_missing(runner, tmp_path, monkeypatc
         projects:
           - id: eclipse-foo
             dependency_track:
-              - project: "Eclipse Foo"
-                product: foo-server
+              project: "Eclipse Foo"
+              products: [foo-server]
         """,
     )
     result = runner.invoke(
@@ -791,8 +842,8 @@ def test_create_dt_projects_command_requires_dt_config(runner, tmp_path, monkeyp
         projects:
           - id: eclipse-foo
             dependency_track:
-              - project: "Eclipse Foo"
-                product: foo-server
+              project: "Eclipse Foo"
+              products: [foo-server]
         """,
     )
     # --dt-url omitted -> refuse before touching DependencyTrack.


### PR DESCRIPTION
The curated file (`projects.yaml`) used to carry a list of DependencyTrack (project, product) mappings per Eclipse Foundation project, each free to name a different root. `dependency_track` is now a single object with one `project` and a non-empty `products` list:

    dependency_track:                     dependency_track:
      - project: "Eclipse CSI"              project: "Eclipse CSI"
        product: pia                  ->    products:
      - project: "Eclipse CSI"                - pia
        product: otterdog                     - otterdog

This means that an Eclipse Foundation project maps to exactly one DependencyTrack root project (e.g. Eclipse CSI), which can have any number of product projects (e.g. pia, otterdog, etc.).

Additionally, `pia sync` now asserts that there are no duplicate DependencyTrack project or product names in the curated file. This means that a DependencyTrack project (root or product) also maps to exactly one Eclipse Foundation project.

Both restrictions are **pure policy decisions** to better align with our real world usage of DependencyTrack in the Eclipse Foundation, and they are enforced by what `pia sync` writes to the database, not by database constraints.

The database schema is deliberately laxer and unchanged by this patch (see the updated comments in the DependencyTrackProject ORM model in models.py).

**Other changes**

The DependencyTrack project uniqueness assertion in `pia sync` is not only about the EF authorization boundary, but it is independently required by DependencyTrack itself: there cannot be two projects with the same name, regardless of the project hierarchy on DependencyTrack. E.g. a product project "cli" cannot live under two different root projects "Eclipse Foo" and "Eclipse Bar". A curated file that asked for that could never be provisioned.

This patch also handles the edge case, where `pia create-dt-projects` tries to create a DependencyTrack project, which is unique in the curated file, but already exists on DependencyTrack: `_dt_create_project` now turns DependencyTrack's 409 into an actionable error message instead of a raw HTTPError traceback.

This patch also fixes a typo in README.md.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Lukas Puehringer <lukas.puehringer@eclipse-foundation.org>