### PR TITLE
Match Jenkins issuer against registered workloads

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -154,8 +154,8 @@ sequenceDiagram
    2. Extract issuer
    3. Verify issuer is known
       - GitHub: Full match: `https://token.actions.githubusercontent.com`
-      - Jenkins: Parse the issuer as a URL and require an `https` scheme with
-        the host exactly equal to `ci.eclipse.org`
+      - Jenkins: Full match against the `issuer` of a Jenkins workload already
+        registered in the workload database.
 3. Token Key Discovery
    1. Fetch OIDC configuration from `{issuer}/.well-known/openid-configuration`
    2. Extract `jwks_uri` from configuration
@@ -170,7 +170,9 @@ sequenceDiagram
    1. Find workload type by issuer
    2. Find workload by matching verified token claims against workload database:
       - GitHub: match `repo_owner`, `repo_name`, `repo_owner_id`
-      - Jenkins: match `issuer`
+      - Jenkins: match `issuer`. (repeats step 2.3, with different semantics: there we
+        check the *unverified* issuer URL to prevent arbitrary requests in steps 3 and 4;
+        here we authenticate a workload based on verified token claims)
 6. Workload-Specific Claim Verification
    - GitHub: `event_name` must be in the allowlist `{push, workflow_dispatch}`.
      Excludes triggers that can be indirectly driven by non-maintainers

--- a/pia/main.py
+++ b/pia/main.py
@@ -111,8 +111,13 @@ async def authenticate(
 
     logger.info(f"Unverified issuer extracted: {unverified_issuer!a}")
 
-    # Inexpensive pre-verification check
-    if not is_issuer_known(unverified_issuer):
+    # Pre-verification check. The issuer URL from the unverified token is used
+    # for OIDC discovery and JWKs requests. It MUST NOT be chosen freely by an
+    # untrusted caller (CWE-918).
+    # NOTE: Issuers that look like Jenkins are matched against registered
+    # Jenkins workloads in the DB. This may be more costly than a pattern
+    # match, but cannot be bypassed.
+    if not is_issuer_known(session, unverified_issuer):
         logger.warning(f"Issuer {unverified_issuer!a} not allowed")
         _401("Issuer not allowed")
 

--- a/pia/models.py
+++ b/pia/models.py
@@ -2,7 +2,6 @@
 
 import logging
 from typing import Any
-from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 from sqlalchemy import ForeignKey, MetaData, Select, String, UniqueConstraint, select
@@ -240,18 +239,22 @@ class DependencyTrackProject(Base):
         )
 
 
-def is_issuer_known(issuer: str) -> bool:
-    """Check if issuer is generally known to PIA.
+def is_issuer_known(session: Session, issuer: str) -> bool:
+    """Check if issuer is known to PIA.
 
     GitHub: issuer must equal GITHUB_ISSUER
-    Jenkins: issuer's scheme and host must equal JENKINS_ISSUER_BASE_URL
-
+    Jenkins: issuer must equal the issuer of a registered JenkinsWorkload in DB
     """
     if issuer == GITHUB_ISSUER:
         return True
 
-    parsed = urlparse(issuer)
-    return f"{parsed.scheme}://{parsed.hostname}" == JENKINS_ISSUER_BASE_URL
+    # Preliminary host check to skip more costly db query below for obvious junk
+    if not issuer.startswith(JENKINS_ISSUER_BASE_URL + "/"):
+        return False
+
+    # More costly, but also more robust than a URL pattern match
+    stmt = select(JenkinsWorkload.id).where(JenkinsWorkload.issuer == issuer)
+    return session.execute(stmt).first() is not None
 
 
 def find_workload_by_claims(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,40 +20,51 @@ GITHUB_ISSUER = "https://token.actions.githubusercontent.com"
 
 
 class TestIsIssuerKnown:
-    def test_github_issuer_known(self):
-        assert is_issuer_known(GITHUB_ISSUER)
+    def test_github_issuer_known(self, seed_db):
+        assert is_issuer_known(seed_db, GITHUB_ISSUER)
 
-    def test_jenkins_issuer_known(self):
-        assert is_issuer_known("https://ci.eclipse.org/eclipse-other/oidc")
-
-    def test_jenkins_issuer_bare_host_known(self):
-        assert is_issuer_known("https://ci.eclipse.org")
-
-    def test_arbitrary_issuer_unknown(self):
-        assert not is_issuer_known("https://attacker.com")
+    def test_jenkins_issuer_known(self, seed_db):
+        assert is_issuer_known(seed_db, "https://ci.eclipse.org/eclipse-other/oidc")
 
     @pytest.mark.parametrize(
         "issuer",
         [
-            # Userinfo before "@": the real host is other.host, not ci.eclipse.org.
+            # Prefix-only match can be bypassed with userinfo or suffix trick.
+            "https://ci.eclipse.org",
             "https://ci.eclipse.org@other.host",
             "https://ci.eclipse.org@127.0.0.1:8888",
-            # Suffix on the host: ci.eclipse.org.other.host is a different host.
             "https://ci.eclipse.org.other.host",
             "https://ci.eclipse.org.other.host/eclipse-x/oidc",
-            # Host is only a prefix substring, not the whole host.
             "https://ci.eclipse.org.evil.example/.well-known/openid-configuration",
+            # Hostname parses differently in urlparse (time of check) vs.
+            # requests/urllib3 (time of use).
+            "https://attacker-evil-host.example:443\\@ci.eclipse.org/",
+            "https://169.254.169.254:443\\@ci.eclipse.org/",
+            "https://169.254.169.254\\@ci.eclipse.org/eclipse-other/oidc",
+            "https://ci.eclipse.org\\.evil.example/eclipse-other/oidc",
+            "https://ci.eclipse.org\t@evil.example/eclipse-other/oidc",
+            "https://ci.eclipse.org\n@evil.example/eclipse-other/oidc",
+            "https://ci.eclipse.org%00@evil.example/eclipse-other/oidc",
+            # Unregistered issuer is rejected, even if the URL is well-formed.
+            "https://ci.eclipse.org/no-such/oidc",
+            # Near-match of registered issuer is rejected.
+            "https://ci.eclipse.org/eclipse-other/oidc@evil.example",
+            "https://ci.eclipse.org/eclipse-other/oidc.evil.example",
+            "https://ci.eclipse.org/eclipse-other/oidc?next=@evil.example",
+            "https://ci.eclipse.org/eclipse-other/oidc#@evil.example",
+            "https://ci.eclipse.org:443/eclipse-other/oidc",
+            "https://CI.ECLIPSE.ORG/eclipse-other/oidc",
+            # Wrong host, scheme, or not a URL at all.
+            "https://attacker.com",
+            "http://ci.eclipse.org/eclipse-other/oidc",
+            "file:///etc/passwd",
+            "ci.eclipse.org",
+            "not a url",
+            "",
         ],
     )
-    def test_issuer_resolving_to_other_host_unknown(self, issuer):
-        assert not is_issuer_known(issuer)
-
-    def test_non_https_jenkins_issuer_unknown(self):
-        assert not is_issuer_known("http://ci.eclipse.org/eclipse-other/oidc")
-
-    def test_malformed_issuer_unknown(self):
-        assert not is_issuer_known("ci.eclipse.org")
-        assert not is_issuer_known("not a url")
+    def test_issuer_unknown(self, seed_db, issuer):
+        assert not is_issuer_known(seed_db, issuer)
 
 
 class TestFindWorkloadByClaims:


### PR DESCRIPTION
The issuer from the unverified token is used for OIDC discovery and JWKS requests, so this gate decides where PIA sends them. Checking it with urlparse let requests/urllib3 resolve a different host: `https://<attacker-host>\@ci.eclipse.org` passed as ci.eclipse.org but was fetched from <attacker-host> — unauthenticated blind SSRF (CWE-918).

Match the issuer for equality against a registered JenkinsWorkload instead. It is no longer parsed, so no parser disagreement is possible, and discovery can only ever target a curated issuer.

Assisted-by: Claude:claude-opus-5